### PR TITLE
Fix visionOS

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -264,7 +264,7 @@ extension _PersistentReference: MutableReference, Equatable where Key: SharedKey
   }
 }
 
-final class _ManagedReference<Key: SharedReaderKey>: Reference {
+final class _ManagedReference<Key: SharedReaderKey>: Reference, Observable {
   private let base: _PersistentReference<Key>
 
   init(_ base: _PersistentReference<Key>) {
@@ -324,7 +324,7 @@ extension _ManagedReference: MutableReference, Equatable where Key: SharedKey {
 
 final class _AppendKeyPathReference<
   Base: Reference, Value, Path: KeyPath<Base.Value, Value> & Sendable
->: Reference {
+>: Reference, Observable {
   private let base: Base
   private let keyPath: Path
 
@@ -386,6 +386,7 @@ where Base: MutableReference, Path: WritableKeyPath<Base.Value, Value> {
 
 final class _OptionalReference<Base: Reference<Value?>, Value>:
   Reference,
+  Observable,
   @unchecked Sendable
 {
   private let base: Base

--- a/Sources/Sharing/SharedBinding.swift
+++ b/Sources/Sharing/SharedBinding.swift
@@ -16,11 +16,23 @@
     /// - Parameter base: A shared reference to a value.
     @MainActor
     public init(_ base: Shared<Value>) {
-      func open(_ reference: some MutableReference<Value>) -> Binding<Value> {
-        @PerceptionCore.Bindable var reference = reference
-        return $reference._wrappedValue
+      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *),
+        // NB: We can't do 'any MutableReference<Value> & Observable' and must force-cast, instead.
+        //     https://github.com/swiftlang/swift/pull/76705
+        let reference = base.reference as? any MutableReference & Observable
+      {
+        func open<V>(_ reference: some MutableReference<V> & Observable) -> Binding<Value> {
+          @SwiftUI.Bindable var reference = reference
+          return $reference._wrappedValue as! Binding<Value>
+        }
+        self = open(reference)
+      } else {
+        func open(_ reference: some MutableReference<Value>) -> Binding<Value> {
+          @PerceptionCore.Bindable var reference = reference
+          return $reference._wrappedValue
+        }
+        self = open(base.reference)
       }
-      self = open(base.reference)
     }
   }
 


### PR DESCRIPTION
Perception's bindable implementation is unavailable on visionOS (maybe it shouldn't be...but we've been back and forth on a lot of those availability checks).

This PR does some runtime checking to dispatch directly to SwiftUI's bindable property wrapper when possible.