### PR TITLE
Fix: Handle inaccessible file paths in `fileSystemSource` to prevent crashes

### DIFF
--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -165,7 +165,7 @@
             try? storage.createDirectory(url.deletingLastPathComponent(), true)
             try? storage.save(Data(), url)
           }
-          let writeCancellable = storage.fileSystemSource(url, [.write]) { [weak self] in
+          let writeCancellable = try? storage.fileSystemSource(url, [.write]) { [weak self] in
             guard let self else { return }
             state.withValue { state in
               let modificationDate =
@@ -184,7 +184,7 @@
               receiveValue(self.load(data: data, initialValue: initialValue))
             }
           }
-          let deleteCancellable = storage.fileSystemSource(url, [.delete, .rename]) { [weak self] in
+          let deleteCancellable = try? storage.fileSystemSource(url, [.delete, .rename]) { [weak self] in
             guard let self else { return }
             state.withValue { state in
               state.workItem?.cancel()
@@ -194,8 +194,8 @@
             setUpSources()
           }
           $0 = SharedSubscription {
-            writeCancellable.cancel()
-            deleteCancellable.cancel()
+            writeCancellable?.cancel()
+            deleteCancellable?.cancel()
           }
         }
       }
@@ -283,7 +283,7 @@
     let createDirectory: @Sendable (URL, Bool) throws -> Void
     let fileExists: @Sendable (URL) -> Bool
     let fileSystemSource:
-      @Sendable (URL, DispatchSource.FileSystemEvent, @escaping @Sendable () -> Void) ->
+      @Sendable (URL, DispatchSource.FileSystemEvent, @escaping @Sendable () -> Void) throws ->
         SharedSubscription
     let load: @Sendable (URL) throws -> Data
     @_spi(Internals) public let save: @Sendable (Data, URL) throws -> Void
@@ -303,8 +303,13 @@
       },
       fileExists: { FileManager.default.fileExists(atPath: $0.path) },
       fileSystemSource: {
+        let fileDescriptor = open($0.path, O_EVTONLY)
+        guard fileDescriptor != -1 else {
+          struct FileDescriptorError: Error {}
+          throw FileDescriptorError()
+        }
         let source = DispatchSource.makeFileSystemObjectSource(
-          fileDescriptor: open($0.path, O_EVTONLY),
+          fileDescriptor: fileDescriptor,
           eventMask: $1,
           queue: DispatchQueue.main
         )


### PR DESCRIPTION
This PR addresses an issue in the handling of file system events within the `fileSystemSource` function. The problem arises when the `open` function, used to create a file descriptor for monitoring file system events, fails and returns `-1`. This typically happens when the system lacks access to the specified file path, either due to permissions or other constraints. If this invalid file descriptor (`-1`) is passed to `DispatchSource.makeFileSystemObjectSource`, the application crashes.

The behavior of the `open` function is defined in the [POSIX documentation](https://pubs.opengroup.org/onlinepubs/007904875/functions/open.html), which states that it returns `-1` when access to the path fails. 

While one could argue that it's a developer error to pass an invalid URL, and I generally agree with this perspective, the liblery could be used by one to provide a functionality for users where they can access files in custom locations. This PR makes such a use case more robust by handling this situation gracefully.
