### PR TITLE
Widen platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
+SWIFT_VERSION = 6.0
+
 format:
 	swift format . --recursive --in-place
 
 docker-build:
-	docker run --rm -v "$(PWD):$(PWD)" -w "$(PWD)" swift:6.0 bash -c "swift build"
+	docker run \
+		--rm \
+		-v "$(PWD):$(PWD)" \
+		-w "$(PWD)" \
+		swift:$(SWIFT_VERSION) \
+		bash -c "swift build"
 
 .PHONY: format

--- a/Sources/Sharing/Internal/NSRecursiveLock+WithLock.swift
+++ b/Sources/Sharing/Internal/NSRecursiveLock+WithLock.swift
@@ -1,0 +1,11 @@
+#if swift(<6) && !os(iOS) && !os(macOS) && !os(tvOS) && !os(watchOS) && !os(visionOS)
+  import Foundation
+
+  extension NSRecursiveLock {
+    func withLock<R>(_ body: () throws -> R) rethrows -> R {
+      lock()
+      defer { unlock() }
+      return try body()
+    }
+  }
+#endif

--- a/Sources/Sharing/SharedBinding.swift
+++ b/Sources/Sharing/SharedBinding.swift
@@ -16,23 +16,28 @@
     /// - Parameter base: A shared reference to a value.
     @MainActor
     public init(_ base: Shared<Value>) {
-      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *),
+      guard
+        #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *),
         // NB: We can't do 'any MutableReference<Value> & Observable' and must force-cast, instead.
         //     https://github.com/swiftlang/swift/pull/76705
         let reference = base.reference as? any MutableReference & Observable
-      {
-        func open<V>(_ reference: some MutableReference<V> & Observable) -> Binding<Value> {
-          @SwiftUI.Bindable var reference = reference
-          return $reference._wrappedValue as! Binding<Value>
-        }
-        self = open(reference)
-      } else {
-        func open(_ reference: some MutableReference<Value>) -> Binding<Value> {
-          @PerceptionCore.Bindable var reference = reference
-          return $reference._wrappedValue
-        }
-        self = open(base.reference)
+      else {
+        #if os(visionOS)
+          fatalError("This should be unreachable: visionOS should always support Observation")
+        #else
+          func open(_ reference: some MutableReference<Value>) -> Binding<Value> {
+            @PerceptionCore.Bindable var reference = reference
+            return $reference._wrappedValue
+          }
+          self = open(base.reference)
+          return
+        #endif
       }
+      func open<V>(_ reference: some MutableReference<V> & Observable) -> Binding<Value> {
+        @SwiftUI.Bindable var reference = reference
+        return $reference._wrappedValue as! Binding<Value>
+      }
+      self = open(reference)
     }
   }
 

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -230,7 +230,7 @@
         expectNoDifference(users, [.blob])
 
         try JSONEncoder().encode([User.blobJr]).write(to: .fileURL)
-        try await Task.sleep(nanoseconds: 1_000_000)
+        try await Task.sleep(nanoseconds: 10_000_000)
         expectNoDifference(users, [.blobJr])
       }
 
@@ -242,7 +242,7 @@
         expectNoDifference(users, [.blob])
 
         try FileManager.default.removeItem(at: .fileURL)
-        try await Task.sleep(nanoseconds: 1_000_000)
+        try await Task.sleep(nanoseconds: 10_000_000)
         expectNoDifference(users, [])
       }
 
@@ -255,7 +255,7 @@
           expectNoDifference(users, [.blob])
 
           try FileManager.default.moveItem(at: .fileURL, to: .anotherFileURL)
-          try await Task.sleep(nanoseconds: 1_000_000)
+          try await Task.sleep(nanoseconds: 10_000_000)
           expectNoDifference(users, [])
 
           try FileManager.default.removeItem(at: .fileURL)
@@ -274,11 +274,11 @@
           expectNoDifference(users, [.blob])
 
           try FileManager.default.removeItem(at: .fileURL)
-          try await Task.sleep(nanoseconds: 1_000_000)
+          try await Task.sleep(nanoseconds: 10_000_000)
           expectNoDifference(users, [])
 
           try JSONEncoder().encode([User.blobJr]).write(to: .fileURL)
-          try await Task.sleep(nanoseconds: 1_000_000)
+          try await Task.sleep(nanoseconds: 10_000_000)
           expectNoDifference(users, [.blobJr])
         }
       }


### PR DESCRIPTION
While #1 and #2 fixed some support for Linux/Windows and visionOS respectively, this PR widens support a bit:

  - Linux/Windows (and other non-Apple platforms) should now compile for pre-Swift 6.

  - visionOS support was limited to iPadOS mode. This PR further fixes things for native visionOS.