### PR TITLE
Decouple database dependency from GRDBQueryKey

### DIFF
--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -10,9 +10,9 @@ protocol GRDBQuery<Value>: Hashable, Sendable {
 
 extension SharedReaderKey {
   /// A shared key that can query for data in a SQLite database.
-  static func grdbQuery<Query>(_ query: Query, animation: Animation? = nil) -> Self
+  static func grdbQuery<Query>(_ query: Query, db: DatabaseQueue, animation: Animation? = nil) -> Self
   where Self == GRDBQueryKey<Query> {
-    GRDBQueryKey(query: query, animation: animation)
+    GRDBQueryKey(query: query, db: db, animation: animation)
   }
 }
 
@@ -28,8 +28,11 @@ where Query.Value: Sendable {
 
   var id: ID { ID(rawValue: query) }
 
-  init(query: Query, animation: Animation? = nil) {
-    @Dependency(\.database) var databaseQueue
+  init(
+    query: Query,
+    db databaseQueue: DatabaseQueue,
+    animation: Animation? = nil
+  ) {
     self.animation = animation
     self.databaseQueue = databaseQueue
     self.query = query

--- a/Examples/GRDBDemo/Schema.swift
+++ b/Examples/GRDBDemo/Schema.swift
@@ -46,8 +46,13 @@ enum PlayerOrder: String { case name, isInjured }
 
 extension SharedReaderKey where Self == GRDBQueryKey<PlayersRequest>.Default {
   static func players(order: PlayerOrder = .name) -> Self {
-    Self[
-      .grdbQuery(PlayersRequest(order: order), animation: .default),
+    @Dependency(\.database) var databaseQueue
+    return Self[
+      .grdbQuery(
+        PlayersRequest(order: order),
+        db: databaseQueue,
+        animation: .default
+      ),
       default: []
     ]
   }


### PR DESCRIPTION
If developers are to rely on the GRDB example as a guide for GRDB integration, it may be better to actually decouple the database dependency from `GRDBQueryKey`. Although everything currently works as-is because everything falls under the same namespace, I am finding that I can't simply copy and paste `GRDBQueryKey` code into my `ComposableArchitectureExtensions` library because the initializer has a database dependency that would be more appropriate to have in a separate library (e.g. `LocalDatabaseClient`). 

I also think this is the way to go because I read somewhere in the Slack channel that the way Point-Free will be supporting GRDB isn't through some official code in the swift-sharing library itself, but rather an example that users can then copy-and-paste (which means it would be on us to maintain it after the code has made its way to our own codebases).