### PR TITLE
Improve the GRDB demo.

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -832,8 +832,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
 			requirement = {
-				branch = "fix-prepare-dependencies";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.6.2;
 			};
 		};
 		CA93A51D2CD27A8C00E420A6 /* XCRemoteSwiftPackageReference "swift-navigation" */ = {

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -830,10 +830,10 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		CA7641682CF4EDCC00C1CE55 /* XCRemoteSwiftPackageReference "swift-dependencies" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pointfreeco/swift-dependencies.git";
+			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.6.1;
+				branch = "fix-prepare-dependencies";
+				kind = branch;
 			};
 		};
 		CA93A51D2CD27A8C00E420A6 /* XCRemoteSwiftPackageReference "swift-navigation" */ = {

--- a/Examples/GRDBDemo/App.swift
+++ b/Examples/GRDBDemo/App.swift
@@ -16,19 +16,3 @@ struct GRDBDemoApp: App {
     }
   }
 }
-
-extension DatabaseQueue {
-  fileprivate static var appDatabase: DatabaseQueue {
-    let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
-    print("open", path)
-    var configuration = Configuration()
-    configuration.prepareDatabase { db in
-      db.trace { event in
-        print(event)
-      }
-    }
-    let databaseQueue = try! DatabaseQueue(path: path, configuration: configuration)
-    try! databaseQueue.migrate()
-    return databaseQueue
-  }
-}

--- a/Examples/GRDBDemo/App.swift
+++ b/Examples/GRDBDemo/App.swift
@@ -1,11 +1,34 @@
 import Dependencies
+import GRDB
 import SwiftUI
 
 @main
 struct GRDBDemoApp: App {
+  init() {
+    prepareDependencies {
+      $0.defaultDatabase = .appDatabase
+    }
+  }
+
   var body: some Scene {
     WindowGroup {
       PlayersView()
     }
+  }
+}
+
+extension DatabaseQueue {
+  fileprivate static var appDatabase: DatabaseQueue {
+    let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
+    print("open", path)
+    var configuration = Configuration()
+    configuration.prepareDatabase { db in
+      db.trace { event in
+        print(event)
+      }
+    }
+    let databaseQueue = try! DatabaseQueue(path: path, configuration: configuration)
+    try! databaseQueue.migrate()
+    return databaseQueue
   }
 }

--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -3,6 +3,19 @@ import GRDB
 import Sharing
 import SwiftUI
 
+extension DependencyValues {
+  public var defaultDatabase: DatabaseQueue {
+    get { self[GRDBDatabaseKey.self] }
+    set { self[GRDBDatabaseKey.self] = newValue }
+  }
+
+  private enum GRDBDatabaseKey: TestDependencyKey {
+    static var testValue: DatabaseQueue {
+      try! DatabaseQueue()
+    }
+  }
+}
+
 protocol GRDBQuery<Value>: Hashable, Sendable {
   associatedtype Value
   func fetch(_ db: Database) throws -> Value
@@ -29,7 +42,7 @@ where Query.Value: Sendable {
   var id: ID { ID(rawValue: query) }
 
   init(query: Query, animation: Animation? = nil) {
-    @Dependency(\.database) var databaseQueue
+    @Dependency(\.defaultDatabase) var databaseQueue
     self.animation = animation
     self.databaseQueue = databaseQueue
     self.query = query

--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -16,16 +16,16 @@ extension DependencyValues {
         the 'grdbQuery' key you can use the 'prepareDependencies' tool as soon as your app \ 
         launches, such as in the entry point:
         
-        @main
-        struct EntryPoint: App {
-          init() {
-            prepareDependencies {
-              $0.defaultDatabase = DatabaseQueue(…)
+            @main
+            struct EntryPoint: App {
+              init() {
+                prepareDependencies {
+                  $0.defaultDatabase = DatabaseQueue(…)
+                }
+              }
+
+              // ...
             }
-          }
-        
-          // ...
-        }
         """)
       return try! DatabaseQueue()
     }

--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -9,7 +9,27 @@ extension DependencyValues {
     set { self[GRDBDatabaseKey.self] = newValue }
   }
 
-  private enum GRDBDatabaseKey: TestDependencyKey {
+  private enum GRDBDatabaseKey: DependencyKey {
+    static var liveValue: DatabaseQueue {
+      reportIssue("""
+        A blank, in-memory database is being used for the app. To set the database that is used by \
+        the 'grdbQuery' key you can use the 'prepareDependencies' tool as soon as your app \ 
+        launches, such as in the entry point:
+        
+        @main
+        struct EntryPoint: App {
+          init() {
+            prepareDependencies {
+              $0.defaultDatabase = DatabaseQueue(…)
+            }
+          }
+        
+          // ...
+        }
+        """)
+      return try! DatabaseQueue()
+    }
+
     static var testValue: DatabaseQueue {
       try! DatabaseQueue()
     }

--- a/Examples/GRDBDemo/PlayersView.swift
+++ b/Examples/GRDBDemo/PlayersView.swift
@@ -15,7 +15,7 @@ private let readMe: LocalizedStringKey = """
   """
 
 struct PlayersView: View {
-  @Dependency(\.database) private var database
+  @Dependency(\.defaultDatabase) private var database
   @SharedReader private var players: [Player]
   @Shared(.appStorage("order")) private var order = PlayerOrder.name
   @State private var addPlayerIsPresented = false
@@ -97,7 +97,7 @@ struct PlayersView: View {
 }
 
 struct AddPlayerView: View {
-  @Dependency(\.database) private var database
+  @Dependency(\.defaultDatabase) private var databaseQueue
   @Environment(\.dismiss) var dismiss
   @State var player = Player()
 
@@ -111,7 +111,7 @@ struct AddPlayerView: View {
       .toolbar {
         Button("Save") {
           do {
-            try database.write { db in
+            try databaseQueue.write { db in
               _ = try player.inserted(db)
             }
           } catch {
@@ -125,8 +125,8 @@ struct AddPlayerView: View {
 }
 
 #Preview {
-  @Dependency(\.database) var database
-  let _ = try! database.write { db in
+  @Dependency(\.defaultDatabase) var databaseQueue
+  let _ = try! databaseQueue.write { db in
     for index in 0...9 {
       _ = try Player(name: "Blob \(index)", isInjured: index.isMultiple(of: 3))
         .inserted(db)

--- a/Examples/GRDBDemo/PlayersView.swift
+++ b/Examples/GRDBDemo/PlayersView.swift
@@ -124,7 +124,9 @@ struct AddPlayerView: View {
   }
 }
 
-#Preview {
+#Preview(
+  traits: .dependency(\.defaultDatabase, .appDatabase)
+) {
   @Dependency(\.defaultDatabase) var databaseQueue
   let _ = try! databaseQueue.write { db in
     for index in 0...9 {

--- a/Examples/GRDBDemo/Schema.swift
+++ b/Examples/GRDBDemo/Schema.swift
@@ -20,6 +20,18 @@ extension Player: Codable, FetchableRecord, MutablePersistableRecord {
 extension DatabaseWriter {
   func migrate() throws {
     var migrator = DatabaseMigrator()
+    defer {
+      #if targetEnvironment(simulator)
+        migrator.registerMigration("Create seed data") { db in
+          try Player.deleteAll(db)
+          for (index, name) in ["Blob", "Blob Jr.", "Blob Sr.", "Blob Esq."].enumerated() {
+            _ = try Player(name: name, isInjured: index.isMultiple(of: 2))
+              .inserted(db)
+          }
+        }
+      #endif
+      try! migrator.migrate(self)
+    }
     #if DEBUG
       migrator.eraseDatabaseOnSchemaChange = true
     #endif
@@ -30,15 +42,6 @@ extension DatabaseWriter {
         t.column("isInjured", .boolean).defaults(to: false).notNull()
       }
     }
-    #if targetEnvironment(simulator)
-    migrator.registerMigration("Create seed data") { db in
-      for (index, name) in ["Blob", "Blob Jr.", "Blob Sr.", "Blob Esq."].enumerated() {
-        _ = try Player(name: name, isInjured: index.isMultiple(of: 2))
-          .inserted(db)
-      }
-    }
-    #endif
-    try migrator.migrate(self)
   }
 }
 
@@ -56,48 +59,17 @@ extension SharedReaderKey where Self == GRDBQueryKey<PlayersRequest>.Default {
 struct PlayersRequest: GRDBQuery {
   let order: PlayerOrder
   func fetch(_ db: Database) throws -> [Player] {
-    let ordering: any SQLOrderingTerm = switch order {
-    case .name:
-      Column("name")
-    case .isInjured:
-      Column("isInjured").desc
-    }
-    return try Player
+    let ordering: any SQLOrderingTerm =
+      switch order {
+      case .name:
+        Column("name")
+      case .isInjured:
+        Column("isInjured").desc
+      }
+    return
+      try Player
       .all()
       .order(ordering)
       .fetchAll(db)
-  }
-}
-
-extension DependencyValues {
-  public var database: DatabaseQueue {
-    get { self[GRDBDatabaseKey.self] }
-    set { self[GRDBDatabaseKey.self] = newValue }
-  }
-}
-
-private enum GRDBDatabaseKey: DependencyKey {
-  static var liveValue: DatabaseQueue {
-    let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
-    print("open", path)
-    var configuration = Configuration()
-    configuration.prepareDatabase { db in
-      db.trace { event in
-        print(event)
-      }
-    }
-    let databaseQueue = try! DatabaseQueue(path: path, configuration: configuration)
-    try! databaseQueue.migrate()
-    return databaseQueue
-  }
-
-  static var previewValue: DatabaseQueue {
-    testValue
-  }
-
-  static var testValue: DatabaseQueue {
-    let databaseQueue = try! DatabaseQueue()
-    try! databaseQueue.migrate()
-    return databaseQueue
   }
 }

--- a/Examples/GRDBDemo/Schema.swift
+++ b/Examples/GRDBDemo/Schema.swift
@@ -73,3 +73,24 @@ struct PlayersRequest: GRDBQuery {
       .fetchAll(db)
   }
 }
+
+extension DatabaseQueue {
+  static var appDatabase: DatabaseQueue {
+    let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
+    print("open", path)
+    var configuration = Configuration()
+    configuration.prepareDatabase { db in
+      db.trace { event in
+        print(event)
+      }
+    }
+    let databaseQueue: DatabaseQueue
+    if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == nil {
+      databaseQueue = try! DatabaseQueue(path: path, configuration: configuration)
+    } else {
+      databaseQueue = try! DatabaseQueue(configuration: configuration)
+    }
+    try! databaseQueue.migrate()
+    return databaseQueue
+  }
+}

--- a/Sharing.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sharing.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "branch" : "fix-prepare-dependencies",
-        "revision" : "e483986d20e784c04e2196dfccdbdfbed395bc3e"
+        "revision" : "5526c8a27675dc7b18d6fa643abfb64bcb200b77",
+        "version" : "1.6.2"
       }
     },
     {

--- a/Sharing.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sharing.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ecc3f7cb8e817cf003b9f8d58c2ef18ea3c992280b37cd2999c9cdf1fdc9c91c",
+  "originHash" : "142ead9a500d4bcfaff29b4c108bc1b476a4ac30da68cc5ffc80ccfc33c6861b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "7d2eb4ad20efb2838269645410d26b64ca48d8aa",
-        "version" : "1.6.1"
+        "branch" : "fix-prepare-dependencies",
+        "revision" : "e483986d20e784c04e2196dfccdbdfbed395bc3e"
       }
     },
     {


### PR DESCRIPTION
Related to #14, we can leverage `prepareDependencies` to push the database dependency into the `GRDBQueryKey` "library" code.