### PR TITLE
Allow creation of nested persistence keys

### DIFF
--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -13,6 +13,48 @@ import Testing
         @Shared(.inMemory("count")) var count: Int = { fatalError() }()
       }
     }
+
+    @Test func nesting() {
+      struct C: Equatable {}
+      struct B {
+        @Shared(.inMemory("c")) var c = C()
+      }
+      struct A {
+        @Shared(.inMemory("b")) var b = B()
+      }
+
+      let a = A()
+      #expect(a.b.c == C())
+    }
+
+    @Test func recursiveNesting() {
+      struct B {
+        @Shared(.inMemory("a")) var a = A()
+      }
+      struct A {
+        @Shared(.inMemory("b")) var b = B()
+      }
+
+      let a = A()
+    }
+
+    @Test func recursiveNesting2() {
+      struct B: Equatable {
+        @Shared var a: A
+        init() {
+          self._a = Shared(wrappedValue: A(), .inMemory("a"))
+        }
+      }
+      struct A: Equatable {
+        @Shared var b: B
+        init() {
+          self._b = Shared(wrappedValue: B(), .inMemory("b"))
+        }
+      }
+
+      let a = A()
+      #expect(a.b.a == a)
+    }
   }
 
   @Suite struct BoxReference {

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -26,35 +26,6 @@ import Testing
       let a = A()
       #expect(a.b.c == C())
     }
-
-    @Test func recursiveNesting() {
-      struct B {
-        @Shared(.inMemory("a")) var a = A()
-      }
-      struct A {
-        @Shared(.inMemory("b")) var b = B()
-      }
-
-      let a = A()
-    }
-
-    @Test func recursiveNesting2() {
-      struct B: Equatable {
-        @Shared var a: A
-        init() {
-          self._a = Shared(wrappedValue: A(), .inMemory("a"))
-        }
-      }
-      struct A: Equatable {
-        @Shared var b: B
-        init() {
-          self._b = Shared(wrappedValue: B(), .inMemory("b"))
-        }
-      }
-
-      let a = A()
-      #expect(a.b.a == a)
-    }
   }
 
   @Suite struct BoxReference {


### PR DESCRIPTION
While potentially inadvisable in certain circumstances, because persistent `@Shared` values are globals, it does seem like it should be possible to create nested shared keys, but because they are locked in a non-recursive way, this can currently cause a deadlock.

This patch lifts this restriction.

Note that _recursive_ keys are typically caught at compile time by Swift, but recursive keys that are assigned at runtime will cause a stack overflow. We could detect this cycle early, though, with a better message if we think it's worth it, but I think the likelihood is small enough that maybe it isn't worth it?