### PR TITLE
Add Any Sendable support to AppStorage persistance strategy

### DIFF
--- a/Sources/Sharing/Documentation.docc/Articles/PersistenceStrategies.md
+++ b/Sources/Sharing/Documentation.docc/Articles/PersistenceStrategies.md
@@ -54,9 +54,10 @@ That small change will guarantee that all changes to `count` are persisted and w
 automatically loaded the next time the application launches.
 
 This form of persistence only works for simple data types because that is what works best with
-`UserDefaults`. This includes strings, booleans, integers, doubles, URLs, data, and more. If you
-need to store more complex data, such as custom data types serialized to bytes, then you will want
-to use the [`.fileStorage`](<doc:PersistenceStrategies#File-storage>) strategy or a 
+`UserDefaults`. This includes strings, booleans, integers, doubles, URLs, data, and more
+([See Apple Documentation](https://developer.apple.com/documentation/foundation/userdefaults/1414067-set#discussion).
+If you need to store more complex data, such as custom data types serialized to bytes, then you will want
+to use the [`.fileStorage`](<doc:PersistenceStrategies#File-storage>) strategy or a
 [custom persistence](<doc:PersistenceStrategies#Custom-persistence>) strategy.
 
 ### File system

--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -190,130 +190,87 @@
       AppStorageKeyID(key: key, store: store.wrappedValue)
     }
 
-    fileprivate init(_ key: String) where Value == Bool {
+    fileprivate init(lookup: any Lookup<Value>, key: String) {
       @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
+      self.lookup = lookup
       self.key = key
       self.store = UncheckedSendable(store)
+    }
+
+    fileprivate init(_ key: String) where Value == Bool {
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Int {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Double {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == String {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == URL {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = URLLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: URLLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Data {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Date {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
+    }
+
+    fileprivate init(_ key: String) where Value: Sendable {
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value: RawRepresentable<Int> {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = RawRepresentableLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: RawRepresentableLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value: RawRepresentable<String> {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = RawRepresentableLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: RawRepresentableLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Bool? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Int? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Double? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == String? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == URL? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: URLLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: URLLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Data? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Date? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init<R: RawRepresentable<Int>>(_ key: String) where Value == R? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: RawRepresentableLookup(base: CastableLookup()))
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: RawRepresentableLookup(base: CastableLookup())), key: key)
     }
 
     fileprivate init<R: RawRepresentable<String>>(_ key: String) where Value == R? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: RawRepresentableLookup(base: CastableLookup()))
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: RawRepresentableLookup(base: CastableLookup())), key: key)
     }
 
     public func load(initialValue: Value?) -> Value? {

--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -76,6 +76,16 @@
       AppStorageKey(key)
     }
 
+    /// Creates a shared key that can read and write to a user default as any Value that can be casted to UserDefaults Any object
+    /// See Apple documentation for supported types: https://developer.apple.com/documentation/foundation/userdefaults/1414067-set#discussion.
+    ///
+    /// - Parameter key: The key to read and write the value to in the user defaults store.
+    /// - Returns: A user defaults shared key.
+    public static func appStorage<Value>(_ key: String) -> Self
+    where Value: Sendable, Self == AppStorageKey<Value> {
+      AppStorageKey(key)
+    }
+
     /// Creates a shared key that can read and write to an integer user default, transforming
     /// that to a `RawRepresentable` data type.
     ///
@@ -156,6 +166,16 @@
     /// - Returns: A user defaults shared key.
     public static func appStorage(_ key: String) -> Self
     where Self == AppStorageKey<Date?> {
+      AppStorageKey(key)
+    }
+
+    /// Creates a shared key that can read and write to a user default as any optional Value that can be casted to UserDefaults Any optional object
+    /// See Apple documentation for supported types: https://developer.apple.com/documentation/foundation/userdefaults/1414067-set#discussion.
+    ///
+    /// - Parameter key: The key to read and write the value to in the user defaults store.
+    /// - Returns: A user defaults shared key.
+    public static func appStorage<Value>(_ key: String) -> Self
+    where Value: Sendable, Self == AppStorageKey<Value?> {
       AppStorageKey(key)
     }
 

--- a/Tests/SharingTests/AppStorageTests.swift
+++ b/Tests/SharingTests/AppStorageTests.swift
@@ -56,6 +56,22 @@
       #expect(date == Date(timeIntervalSince1970: 0))
     }
 
+    @Test func customCastableArray() throws {
+      @Shared(.appStorage("custom-castable-array")) var array: [String] = ["Blob, Jr.", "Blob Sr"]
+      let storeArray = try #require(store.object(forKey: "custom-castable-array") as? [String])
+      #expect(storeArray == ["Blob, Jr.", "Blob Sr"])
+      store.set(["Blob, Jr."], forKey: "custom-castable-array")
+      #expect(array == ["Blob, Jr."])
+    }
+
+    @Test func customCastableDictionary() throws {
+      @Shared(.appStorage("custom-castable-dictionary")) var dictionary: [String: String] = ["1": "Blob, Jr.", "2": "Blob Sr"]
+      let storeDictionary = try #require(store.object(forKey: "custom-castable-dictionary") as? [String: String])
+      #expect(storeDictionary == ["1": "Blob, Jr.", "2": "Blob Sr"])
+      store.set(["2": "Blob, Jr."], forKey: "custom-castable-dictionary")
+      #expect(dictionary == ["2": "Blob, Jr."])
+    }
+
     @Test func rawRepresentableInt() {
       struct ID: RawRepresentable {
         var rawValue: Int


### PR DESCRIPTION
### Motivation
Standard AppStorage SwiftUI property wrapper supports just primitives same as the current AppStorage implementation. However, UserDefaults is able to store any data type that is compatible with the property list data structure, such as Arrays and Dictionaries.

### Downsides

We are giving the user the ability to specify any type as input for AppStorage persistence, which may lead to crashes when trying to save an object that is not a property list object. However, it gives more flexibility on what could be saved, and I can see escapes that it may be used for.

### Questions
1. Should we somehow warn the user when using Castable lookup for objects that are not permitted in a property list?
2. Should we allow the user to have custom wrap and unwrap methods and allow them to extend the current AppStorage functionality?(could be used for storing Codable, for example) - This could be my next PR if you will answer this question as yes, I have already prepared code on a separate branch