### PR TITLE
Add custom objects support to AppStorage persistance strategy

### DIFF
--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -190,130 +190,83 @@
       AppStorageKeyID(key: key, store: store.wrappedValue)
     }
 
-    fileprivate init(_ key: String) where Value == Bool {
+    fileprivate init(lookup: any Lookup<Value>, key: String) {
       @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
+      self.lookup = lookup
       self.key = key
       self.store = UncheckedSendable(store)
+    }
+
+    fileprivate init(_ key: String) where Value == Bool {
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Int {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Double {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == String {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == URL {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = URLLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: URLLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Data {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Date {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = CastableLookup()
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: CastableLookup(), key: key)
     }
 
     fileprivate init(_ key: String) where Value: RawRepresentable<Int> {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = RawRepresentableLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: RawRepresentableLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value: RawRepresentable<String> {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = RawRepresentableLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: RawRepresentableLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Bool? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Int? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Double? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == String? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == URL? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: URLLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: URLLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Data? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init(_ key: String) where Value == Date? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: CastableLookup())
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: CastableLookup()), key: key)
     }
 
     fileprivate init<R: RawRepresentable<Int>>(_ key: String) where Value == R? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: RawRepresentableLookup(base: CastableLookup()))
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: RawRepresentableLookup(base: CastableLookup())), key: key)
     }
 
     fileprivate init<R: RawRepresentable<String>>(_ key: String) where Value == R? {
-      @Dependency(\.defaultAppStorage) var store
-      self.lookup = OptionalLookup(base: RawRepresentableLookup(base: CastableLookup()))
-      self.key = key
-      self.store = UncheckedSendable(store)
+      self.init(lookup: OptionalLookup(base: RawRepresentableLookup(base: CastableLookup())), key: key)
     }
 
     public func load(initialValue: Value?) -> Value? {


### PR DESCRIPTION
### Motivation

The Standard AppStorage SwiftUI property wrapper currently supports only primitive data types, similar to the existing AppStorage implementation. However, UserDefaults can store any data type that is compatible with the property list data structure, including arrays and dictionaries. In contrast to [PR](https://github.com/pointfreeco/swift-sharing/pull/17), this proposed implementation offers greater flexibility in customization to the user rather than imposing restrictions on the library. While we aim to maintain the current functionality, this approach provides users with the ability to tailor their usage as needed.