### PR TITLE
Assertion warning improvements

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -144,7 +144,7 @@ final class _BoxReference<Value>: MutableReference, Observable, Perceptible, @un
   }
 
   var description: String {
-    "Shared<\(Value.self)>(value: \(String(reflecting: wrappedValue)))"
+    "value: \(String(reflecting: wrappedValue))"
   }
 }
 
@@ -251,7 +251,7 @@ final class _PersistentReference<Key: SharedReaderKey>:
   }
 
   var description: String {
-    "Shared\(key is any SharedKey ? "" : "Reader")<\(Key.Value.self)>(\(String(reflecting: key)))"
+    String(reflecting: key)
   }
 }
 
@@ -482,7 +482,7 @@ final class _OptionalReference<Base: Reference<Value?>, Value>:
   #endif
 
   var description: String {
-    "Shared(\(base.description))!"
+    "\(base.description)!"
   }
 }
 

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -24,12 +24,6 @@ protocol Reference<Value>:
   #endif
 }
 
-extension Reference {
-  public var description: String {
-    "\(wrappedValue)"
-  }
-}
-
 protocol MutableReference<Value>: Reference, Equatable {
   var snapshot: Value? { get set }
   func withLock<R>(_ body: (inout Value) throws -> R) rethrows -> R
@@ -128,6 +122,10 @@ final class _BoxReference<Value>: MutableReference, Observable, Perceptible, @un
         return try mutation()
       }
     #endif
+  }
+
+  var description: String {
+    "Shared(value: \(String(reflecting: wrappedValue))"
   }
 }
 
@@ -232,6 +230,10 @@ final class _PersistentReference<Key: SharedReaderKey>:
       }
     #endif
   }
+
+  var description: String {
+    "Shared(\(String(reflecting: key)))"
+  }
 }
 
 extension _PersistentReference: MutableReference, Equatable where Key: SharedKey {
@@ -297,6 +299,10 @@ final class _ManagedReference<Key: SharedReaderKey>: Reference, Observable {
       base.publisher
     }
   #endif
+
+  var description: String {
+    base.description
+  }
 }
 
 extension _ManagedReference: MutableReference, Equatable where Key: SharedKey {
@@ -357,6 +363,10 @@ final class _AppendKeyPathReference<
       return open(base.publisher)
     }
   #endif
+
+  var description: String {
+    "\(base.description)[dynamicMember: \(keyPath)]"
+  }
 }
 
 extension _AppendKeyPathReference: MutableReference, Equatable
@@ -424,6 +434,10 @@ final class _OptionalReference<Base: Reference<Value?>, Value>:
       return open(base.publisher)
     }
   #endif
+
+  var description: String {
+    "Shared(\(base.description))!"
+  }
 }
 
 extension _OptionalReference: MutableReference, Equatable where Base: MutableReference {
@@ -502,6 +516,10 @@ extension _OptionalReference: MutableReference, Equatable where Base: MutableRef
 
     func resetCache() {
       cachedValue = wrappedValue
+    }
+
+    var description: String {
+      base.description
     }
   }
 

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -144,7 +144,7 @@ final class _BoxReference<Value>: MutableReference, Observable, Perceptible, @un
   }
 
   var description: String {
-    "Shared(value: \(String(reflecting: wrappedValue))"
+    "Shared<\(Value.self)>(value: \(String(reflecting: wrappedValue)))"
   }
 }
 
@@ -251,7 +251,7 @@ final class _PersistentReference<Key: SharedReaderKey>:
   }
 
   var description: String {
-    "Shared(\(String(reflecting: key)))"
+    "Shared\(key is any SharedKey ? "" : "Reader")<\(Key.Value.self)>(\(String(reflecting: key)))"
   }
 }
 

--- a/Sources/Sharing/Internal/SharedChangeTracker.swift
+++ b/Sources/Sharing/Internal/SharedChangeTracker.swift
@@ -17,7 +17,7 @@ public struct SharedChangeTracker: Hashable, Sendable {
         reportIssue(
           """
           Tracked unasserted changes to \
-          'Shared<\(type(of: change.value))>(\(String(reflecting: change.key)))': \
+          'Shared<\(typeName(type(of: change.value)))>(\(String(reflecting: change.key)))': \
           \(String(reflecting: change.value)) → \(String(reflecting: change.key.wrappedValue))
           """,
           fileID: change.fileID,

--- a/Sources/Sharing/Internal/SharedChangeTracker.swift
+++ b/Sources/Sharing/Internal/SharedChangeTracker.swift
@@ -8,6 +8,7 @@ public struct SharedChangeTracker: Hashable, Sendable {
     private let lock = NSRecursiveLock()
     private var storage: [ObjectIdentifier: any AnyChange] = [:]
     deinit {
+      guard isTesting else { return }
       forEach { change in
         reportIssue(
           """

--- a/Sources/Sharing/Internal/SharedChangeTracker.swift
+++ b/Sources/Sharing/Internal/SharedChangeTracker.swift
@@ -16,7 +16,8 @@ public struct SharedChangeTracker: Hashable, Sendable {
       forEach { change in
         reportIssue(
           """
-          Tracked unasserted changes to '\(String(reflecting: change.key))': \
+          Tracked unasserted changes to \
+          'Shared<\(type(of: change.value))>(\(String(reflecting: change.key)))': \
           \(String(reflecting: change.value)) → \(String(reflecting: change.key.wrappedValue))
           """,
           fileID: change.fileID,

--- a/Sources/Sharing/Internal/TypeName.swift
+++ b/Sources/Sharing/Internal/TypeName.swift
@@ -1,0 +1,46 @@
+func typeName(
+  _ type: Any.Type,
+  qualified: Bool = true,
+  genericsAbbreviated: Bool = true
+) -> String {
+  var name = _typeName(type, qualified: qualified)
+    .replacingOccurrences(
+      of: #"\(unknown context at \$[[:xdigit:]]+\)\."#,
+      with: "",
+      options: .regularExpression
+    )
+  for _ in 1...10 {  // NB: Only handle so much nesting
+    let abbreviated =
+      name
+      .replacingOccurrences(
+        of: #"\bSwift.Optional<([^><]+)>"#,
+        with: "$1?",
+        options: .regularExpression
+      )
+      .replacingOccurrences(
+        of: #"\bSwift.Array<([^><]+)>"#,
+        with: "[$1]",
+        options: .regularExpression
+      )
+      .replacingOccurrences(
+        of: #"\bSwift.Dictionary<([^,<]+), ([^><]+)>"#,
+        with: "[$1: $2]",
+        options: .regularExpression
+      )
+    if abbreviated == name { break }
+    name = abbreviated
+  }
+  name = name.replacingOccurrences(
+    of: #"\w+\.([\w.]+)"#,
+    with: "$1",
+    options: .regularExpression
+  )
+  if genericsAbbreviated {
+    name = name.replacingOccurrences(
+      of: #"<.+>"#,
+      with: "",
+      options: .regularExpression
+    )
+  }
+  return name
+}

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -329,7 +329,7 @@ public struct Shared<Value> {
 
 extension Shared: CustomStringConvertible {
   public var description: String {
-    (reference.description)
+    "\(Self.self)(\(reference.description))"
   }
 }
 

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -329,7 +329,7 @@ public struct Shared<Value> {
 
 extension Shared: CustomStringConvertible {
   public var description: String {
-    "\(Self.self)(\(reference))"
+    (reference.description)
   }
 }
 

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -329,7 +329,7 @@ public struct Shared<Value> {
 
 extension Shared: CustomStringConvertible {
   public var description: String {
-    "\(Self.self)(\(reference.description))"
+    "\(typeName(Self.self, genericsAbbreviated: false))(\(reference.description))"
   }
 }
 

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -128,15 +128,35 @@ public struct Shared<Value> {
   /// - Parameter operation: An operation given mutable, isolated access to the underlying shared
   ///   value.
   /// - Returns: The value returned from `operation`.
-  public func withLock<R>(_ operation: (inout Value) throws -> R) rethrows -> R {
+  public func withLock<R>(
+    _ operation: (inout Value) throws -> R,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+  ) rethrows -> R {
     try reference.withLock { value in
       @Dependency(\.snapshots) var snapshots
       if snapshots.isAsserting {
         var snapshot = reference.snapshot ?? reference.wrappedValue
-        defer { reference.snapshot = snapshot }
+        defer {
+          reference.takeSnapshot(
+            snapshot,
+            fileID: fileID,
+            filePath: filePath,
+            line: line,
+            column: column
+          )
+        }
         return try operation(&snapshot)
       } else if snapshots.isTracking, reference.snapshot == nil {
-        reference.snapshot = value
+        reference.takeSnapshot(
+          value,
+          fileID: fileID,
+          filePath: filePath,
+          line: line,
+          column: column
+        )
       }
       return try operation(&value)
     }

--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -441,6 +441,12 @@
     #endif
   }
 
+  extension AppStorageKey: CustomStringConvertible {
+    public var description: String {
+      ".appStorage(\(String(reflecting: key)))"
+    }
+  }
+
   public struct AppStorageKeyID: Hashable {
     fileprivate let key: String
     fileprivate let store: UserDefaults

--- a/Sources/Sharing/SharedKeys/DefaultKey.swift
+++ b/Sources/Sharing/SharedKeys/DefaultKey.swift
@@ -66,7 +66,7 @@ extension _SharedKeyDefault: SharedKey where Base: SharedKey {
 extension _SharedKeyDefault: CustomStringConvertible {
   public var description: String {
     """
-    \(typeName(type(of: base), genericsAbbreviated: true))\
+    \(typeName(type(of: base), genericsAbbreviated: false))\
     .Default[\(base), default: \(defaultValue())]
     """
   }

--- a/Sources/Sharing/SharedKeys/DefaultKey.swift
+++ b/Sources/Sharing/SharedKeys/DefaultKey.swift
@@ -62,3 +62,12 @@ extension _SharedKeyDefault: SharedKey where Base: SharedKey {
     base.save(value, immediately: immediately)
   }
 }
+
+extension _SharedKeyDefault: CustomStringConvertible {
+  public var description: String {
+    """
+    \(typeName(type(of: base), genericsAbbreviated: true))\
+    .Default[\(base), default: \(defaultValue())]
+    """
+  }
+}

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -223,6 +223,12 @@
     }
   }
 
+  extension FileStorageKey: CustomStringConvertible {
+    public var description: String {
+      ".fileStorage(\(String(reflecting: url)))"
+    }
+  }
+
   public struct FileStorageKeyID: Hashable {
     fileprivate let url: URL
     fileprivate let storage: FileStorage

--- a/Sources/Sharing/SharedKeys/InMemoryKey.swift
+++ b/Sources/Sharing/SharedKeys/InMemoryKey.swift
@@ -54,6 +54,12 @@ public struct InMemoryKey<Value: Sendable>: SharedKey {
   }
 }
 
+extension InMemoryKey: CustomStringConvertible {
+  public var description: String {
+    ".inMemory(\(String(reflecting: key)))"
+  }
+}
+
 public struct InMemoryStorage: Hashable, Sendable {
   private let id = UUID()
   fileprivate let values = Values()

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -217,7 +217,7 @@ public struct SharedReader<Value> {
 
 extension SharedReader: CustomStringConvertible {
   public var description: String {
-    "\(Self.self)(\(reference.description))"
+    "\(typeName(Self.self, genericsAbbreviated: false))(\(reference.description))"
   }
 }
 

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -217,7 +217,7 @@ public struct SharedReader<Value> {
 
 extension SharedReader: CustomStringConvertible {
   public var description: String {
-    "\(Self.self)(\(wrappedValue))"
+    "\(Self.self)(\(reference.description))"
   }
 }
 

--- a/Tests/SharingTests/SharedChangeTrackerTests.swift
+++ b/Tests/SharingTests/SharedChangeTrackerTests.swift
@@ -75,4 +75,21 @@ import Testing
       #expect($stats == $stats)
     }
   }
+
+  @Test func unassertedChanges() {
+    @Shared(value: 0) var count
+
+    withKnownIssue {
+      do {
+        let tracker = SharedChangeTracker()
+        tracker.track {
+          $count.withLock { $0 += 1 }
+        }
+      }
+    } matching: {
+      $0.description == """
+        Issue recorded: Tracked unasserted changes to 'Shared<Int>(value: 1)': 0 → 1
+        """
+    }
+  }
 }

--- a/Tests/SharingTests/SharedChangeTrackerTests.swift
+++ b/Tests/SharingTests/SharedChangeTrackerTests.swift
@@ -92,4 +92,13 @@ import Testing
         """
     }
   }
+
+  @Test func unreportedChanges() {
+    @Shared(value: 0) var count
+
+    let tracker = SharedChangeTracker(reportUnassertedChanges: false)
+    tracker.track {
+      $count.withLock { $0 += 1 }
+    }
+  }
 }

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import IdentifiedCollections
 import PerceptionCore
 import Sharing
@@ -168,6 +169,18 @@ import Testing
       #expect($count.description == #"Shared<Int>(.appStorage("count"))"#)
 
       #expect(SharedReader($count).description == #"SharedReader<Int>(.appStorage("count"))"#)
+    }
+
+    @Test func fileStorageDescription() {
+      @Shared(.fileStorage(URL(filePath: "/"))) var count = 0
+
+      #expect($count.description == #"Shared<Int>(.fileStorage(file:///))"#)
+    }
+
+    @Test func inMemory() {
+      @Shared(.inMemory("count")) var count = 0
+
+      #expect($count.description == #"Shared<Int>(.inMemory("count"))"#)
     }
 
     @Test func customDump() {

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -158,12 +158,16 @@ import Testing
       @Shared(value: 0) var count
 
       #expect($count.description == "Shared<Int>(value: 0)")
+
+      #expect(SharedReader($count).description == "SharedReader<Int>(value: 0)")
     }
 
     @Test func appStorageDescription() {
       @Shared(.appStorage("count")) var count = 0
 
       #expect($count.description == #"Shared<Int>(.appStorage("count"))"#)
+
+      #expect(SharedReader($count).description == #"SharedReader<Int>(.appStorage("count"))"#)
     }
 
     @Test func customDump() {

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -154,10 +154,16 @@ import Testing
   }
 
   @Suite struct StringRepresentations {
-    @Test func description() {
+    @Test func valueDescription() {
       @Shared(value: 0) var count
 
-      #expect($count.description == "Shared<Int>(0)")
+      #expect($count.description == "Shared<Int>(value: 0)")
+    }
+
+    @Test func appStorageDescription() {
+      @Shared(.appStorage("count")) var count = 0
+
+      #expect($count.description == #"Shared<Int>(.appStorage("count"))"#)
     }
 
     @Test func customDump() {


### PR DESCRIPTION
This PR fixes a few things when it comes to change tracking:

1. It improves the issue messaging when a change happens and isn't asserted against:

    <img width="562" alt="image" src="https://github.com/user-attachments/assets/621fdfbe-6bf3-4970-995f-50b9d6af5731">

2. It collocates these issues with the associated `Shared.withLock`.

3. It allows the change tracker to be configured with whether or not it should report issues, defaulting to whether or not we are in a test context (currently, TCA's `_printChanges` operator can erroneously report issues).