### PR TITLE
Reduce `Shared.init` overloads

### DIFF
--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -51,21 +51,7 @@ extension Shared {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
   public init(_ key: _SharedKeyDefault<some SharedKey<Value>>) {
-    self.init(wrappedValue: key.defaultValue(), key.base)
-  }
-
-  /// Creates a shared reference to a value using a shared key by overriding its default value.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default value that is used when no value can be returned from the
-  ///     shared key.
-  ///   - key: A shared key associated with the shared reference. It is responsible for loading
-  ///     and saving the shared reference's value from some external source.
-  public init(
-    wrappedValue: @autoclosure () -> Value,
-    _ key: _SharedKeyDefault<some SharedKey<Value>>
-  ) {
-    self.init(wrappedValue: wrappedValue(), key.base)
+    self.init(wrappedValue: key.defaultValue(), key)
   }
 
   /// Creates a shared reference to a value using a shared key.

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -95,37 +95,13 @@ extension SharedReader {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
   public init(_ key: _SharedKeyDefault<some SharedReaderKey<Value>>) {
-    self.init(wrappedValue: key.defaultValue(), key.base)
+    self.init(wrappedValue: key.defaultValue(), key)
   }
 
   @_disfavoredOverload
   @_documentation(visibility: private)
   public init(_ key: _SharedKeyDefault<some SharedKey<Value>>) {
-    self.init(wrappedValue: key.defaultValue(), key.base)
-  }
-
-  /// Creates a shared reference to a read-only value using a shared key by overriding its
-  /// default value.
-  ///
-  /// - Parameters:
-  ///   - wrappedValue: A default value that is used when no value can be returned from the
-  ///     shared key.
-  ///   - key: A shared key associated with the shared reference. It is responsible for loading
-  ///     and saving the shared reference's value from some external source.
-  public init(
-    wrappedValue: @autoclosure () -> Value,
-    _ key: _SharedKeyDefault<some SharedReaderKey<Value>>
-  ) {
-    self.init(wrappedValue: wrappedValue(), key.base)
-  }
-
-  @_disfavoredOverload
-  @_documentation(visibility: private)
-  public init(
-    wrappedValue: @autoclosure () -> Value,
-    _ key: _SharedKeyDefault<some SharedKey<Value>>
-  ) {
-    self.init(wrappedValue: wrappedValue(), key.base)
+    self.init(wrappedValue: key.defaultValue(), key)
   }
 
   /// Creates a shared reference to a read-only value using a shared key.


### PR DESCRIPTION
We have a few overloads around `SharedKey.Default` that _seem_ superfluous, but at the same time I remember considering them back in TCA. I think the main concern might have been that given a default `.isOn` key, these would lead to 2 independent global references:

```swift
@Shared(.isOn) var isOn
@Shared(.isOn) var isOn = true
```

But because `SharedKey.Default` has the same hashable `id` as its base strategy, that's not actually the case.

Removing the overloads still leads to a fully-passing test suite, so this branch is mainly an attempt to explore and recapture any problem should it exist, and if we discover these overloads are there for a reason, we should capture the behavior in some tests. And if no problem exists, we could consider removing the overload space.