### PR TITLE
Fix pre-iOS 17 view observation

### DIFF
--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -318,9 +318,12 @@ public struct Shared<Value> {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }
         _ = state.wrappedValue
         lock.withLock {
-          cancellable = _reference.publisher.sink { _ in
-            state.wrappedValue += 1
+          func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
+            publisher.dropFirst().sink { _ in
+              state.wrappedValue += 1
+            }
           }
+          cancellable = open(_reference.publisher)
         }
       }
     #endif

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -317,14 +317,13 @@ public struct Shared<Value> {
       func subscribe(state: State<Int>) {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }
         _ = state.wrappedValue
-        lock.withLock {
-          func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
-            publisher.dropFirst().sink { _ in
-              state.wrappedValue += 1
-            }
+        func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
+          publisher.dropFirst().sink { _ in
+            state.wrappedValue += 1
           }
-          cancellable = open(_reference.publisher)
         }
+        let cancellable = open(_reference.publisher)
+        lock.withLock { self.cancellable = cancellable }
       }
     #endif
   }

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -319,7 +319,7 @@ public struct Shared<Value> {
         _ = state.wrappedValue
         func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
           publisher.dropFirst().sink { _ in
-            state.wrappedValue += 1
+            state.wrappedValue &+= 1
           }
         }
         let cancellable = open(_reference.publisher)

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -205,14 +205,13 @@ public struct SharedReader<Value> {
       func subscribe(state: State<Int>) {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }
         _ = state.wrappedValue
-        lock.withLock {
-          func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
-            publisher.dropFirst().sink { _ in
-              state.wrappedValue += 1
-            }
+        func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
+          publisher.dropFirst().sink { _ in
+            state.wrappedValue += 1
           }
-          cancellable = open(_reference.publisher)
         }
+        let cancellable = open(_reference.publisher)
+        lock.withLock { self.cancellable = cancellable }
       }
     #endif
   }

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -207,7 +207,7 @@ public struct SharedReader<Value> {
         _ = state.wrappedValue
         func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
           publisher.dropFirst().sink { _ in
-            state.wrappedValue += 1
+            state.wrappedValue &+= 1
           }
         }
         let cancellable = open(_reference.publisher)

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -206,9 +206,12 @@ public struct SharedReader<Value> {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }
         _ = state.wrappedValue
         lock.withLock {
-          cancellable = _reference.publisher.sink { _ in
-            state.wrappedValue += 1
+          func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
+            publisher.dropFirst().sink { _ in
+              state.wrappedValue += 1
+            }
           }
+          cancellable = open(_reference.publisher)
         }
       }
     #endif


### PR DESCRIPTION
`@Shared` acts as a dynamic property on iOS <17 by maintaining some internal `@State` and perturbing it when the underlying values changes and publishes a new value. In swift-sharing 1.0, however, we started publishing a value upon first subscribing to this publisher, which leads to an extra mutation of `@State`, usually during the view update (which can cause a runtime warning). This PR skips that first mutation to avoid this issue.