### PR TITLE
Make `GRDBQueryKey` generic over value

### DIFF
--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -80,7 +80,7 @@ struct GRDBQueryKey<Value: Sendable>: SharedReaderKey {
       in: databaseQueue,
       scheduling: .animation(animation)
     ) { error in
-
+      reportIssue(error)
     } onChange: { newValue in
       receiveValue(newValue)
     }

--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -5,13 +5,17 @@ import SwiftUI
 
 extension SharedReaderKey {
   /// A shared key that can query for data in a SQLite database.
-  static func grdbQuery<Value>(_ query: some GRDBQuery<Value>, animation: Animation? = nil) -> Self
+  static func grdbQuery<Value>(
+    _ query: some GRDBQuery<Value>,
+    animation: Animation? = nil
+  ) -> Self
   where Self == GRDBQueryKey<Value> {
     GRDBQueryKey(query: query, animation: animation)
   }
 }
 
 extension DependencyValues {
+  /// The default database used by ``Sharing/SharedReaderKey/grdbQuery(_:animation:)``.
   public var defaultDatabase: DatabaseQueue {
     get { self[GRDBDatabaseKey.self] }
     set { self[GRDBDatabaseKey.self] = newValue }
@@ -115,7 +119,7 @@ private struct AnimatedScheduler: ValueObservationScheduler {
 }
 
 extension ValueObservationScheduler where Self == AnimatedScheduler {
-  static func animation(_ animation: Animation?) -> Self {
+  fileprivate static func animation(_ animation: Animation?) -> Self {
     AnimatedScheduler(animation: animation)
   }
 }

--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -11,7 +11,8 @@ extension DependencyValues {
 
   private enum GRDBDatabaseKey: DependencyKey {
     static var liveValue: DatabaseQueue {
-      reportIssue("""
+      reportIssue(
+        """
         A blank, in-memory database is being used for the app. To set the database that is used by \
         the 'grdbQuery' key you can use the 'prepareDependencies' tool as soon as your app \ 
         launches, such as in the entry point:
@@ -20,13 +21,14 @@ extension DependencyValues {
             struct EntryPoint: App {
               init() {
                 prepareDependencies {
-                  $0.defaultDatabase = DatabaseQueue(…)
+                  $0.defaultDatabase = try! DatabaseQueue(/* ... */)
                 }
               }
 
               // ...
             }
-        """)
+        """
+      )
       return try! DatabaseQueue()
     }
 
@@ -96,7 +98,7 @@ struct GRDBQueryID: Hashable {
   }
 }
 
-struct AnimatedScheduler: ValueObservationScheduler {
+private struct AnimatedScheduler: ValueObservationScheduler {
   let animation: Animation?
   func immediateInitialValue() -> Bool { true }
   func schedule(_ action: @escaping @Sendable () -> Void) {

--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -3,6 +3,14 @@ import GRDB
 import Sharing
 import SwiftUI
 
+extension SharedReaderKey {
+  /// A shared key that can query for data in a SQLite database.
+  static func grdbQuery<Value>(_ query: some GRDBQuery<Value>, animation: Animation? = nil) -> Self
+  where Self == GRDBQueryKey<Value> {
+    GRDBQueryKey(query: query, animation: animation)
+  }
+}
+
 extension DependencyValues {
   public var defaultDatabase: DatabaseQueue {
     get { self[GRDBDatabaseKey.self] }
@@ -41,14 +49,6 @@ extension DependencyValues {
 protocol GRDBQuery<Value>: Hashable, Sendable {
   associatedtype Value
   func fetch(_ db: Database) throws -> Value
-}
-
-extension SharedReaderKey {
-  /// A shared key that can query for data in a SQLite database.
-  static func grdbQuery<Value>(_ query: some GRDBQuery<Value>, animation: Animation? = nil) -> Self
-  where Self == GRDBQueryKey<Value> {
-    GRDBQueryKey(query: query, animation: animation)
-  }
 }
 
 struct GRDBQueryKey<Value: Sendable>: SharedReaderKey {

--- a/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
+++ b/Examples/GRDBDemo/GRDB/GRDBQueryKey.swift
@@ -16,13 +16,13 @@ extension SharedReaderKey {
 
 extension DependencyValues {
   /// The default database used by ``Sharing/SharedReaderKey/grdbQuery(_:animation:)``.
-  public var defaultDatabase: DatabaseQueue {
+  public var defaultDatabase: any DatabaseWriter {
     get { self[GRDBDatabaseKey.self] }
     set { self[GRDBDatabaseKey.self] = newValue }
   }
 
   private enum GRDBDatabaseKey: DependencyKey {
-    static var liveValue: DatabaseQueue {
+    static var liveValue: any DatabaseWriter {
       reportIssue(
         """
         A blank, in-memory database is being used for the app. To set the database that is used by \
@@ -44,7 +44,7 @@ extension DependencyValues {
       return try! DatabaseQueue()
     }
 
-    static var testValue: DatabaseQueue {
+    static var testValue: any DatabaseWriter {
       try! DatabaseQueue()
     }
   }
@@ -57,7 +57,7 @@ protocol GRDBQuery<Value>: Hashable, Sendable {
 
 struct GRDBQueryKey<Value: Sendable>: SharedReaderKey {
   let animation: Animation?
-  let databaseQueue: DatabaseQueue
+  let databaseQueue: any DatabaseWriter
   let query: any GRDBQuery<Value>
 
   typealias ID = GRDBQueryID

--- a/Examples/GRDBDemo/PlayersView.swift
+++ b/Examples/GRDBDemo/PlayersView.swift
@@ -97,7 +97,7 @@ struct PlayersView: View {
 }
 
 struct AddPlayerView: View {
-  @Dependency(\.defaultDatabase) private var databaseQueue
+  @Dependency(\.defaultDatabase) private var database
   @Environment(\.dismiss) var dismiss
   @State var player = Player()
 
@@ -111,7 +111,7 @@ struct AddPlayerView: View {
       .toolbar {
         Button("Save") {
           do {
-            try databaseQueue.write { db in
+            try database.write { db in
               _ = try player.inserted(db)
             }
           } catch {
@@ -127,8 +127,8 @@ struct AddPlayerView: View {
 #Preview(
   traits: .dependency(\.defaultDatabase, .appDatabase)
 ) {
-  @Dependency(\.defaultDatabase) var databaseQueue
-  let _ = try! databaseQueue.write { db in
+  @Dependency(\.defaultDatabase) var database
+  let _ = try! database.write { db in
     for index in 0...9 {
       _ = try Player(name: "Blob \(index)", isInjured: index.isMultiple(of: 3))
         .inserted(db)

--- a/Examples/GRDBDemo/Schema.swift
+++ b/Examples/GRDBDemo/Schema.swift
@@ -45,35 +45,6 @@ extension DatabaseWriter {
   }
 }
 
-enum PlayerOrder: String { case name, isInjured }
-
-extension SharedReaderKey where Self == GRDBQueryKey<[Player]>.Default {
-  static func players(order: PlayerOrder = .name) -> Self {
-    Self[
-      .grdbQuery(PlayersRequest(order: order), animation: .default),
-      default: []
-    ]
-  }
-}
-
-struct PlayersRequest: GRDBQuery {
-  let order: PlayerOrder
-  func fetch(_ db: Database) throws -> [Player] {
-    let ordering: any SQLOrderingTerm =
-      switch order {
-      case .name:
-        Column("name")
-      case .isInjured:
-        Column("isInjured").desc
-      }
-    return
-      try Player
-      .all()
-      .order(ordering)
-      .fetchAll(db)
-  }
-}
-
 extension DatabaseWriter where Self == DatabaseQueue {
   static var appDatabase: Self {
     let path = URL.documentsDirectory.appending(component: "db.sqlite").path()

--- a/Examples/GRDBDemo/Schema.swift
+++ b/Examples/GRDBDemo/Schema.swift
@@ -74,8 +74,8 @@ struct PlayersRequest: GRDBQuery {
   }
 }
 
-extension DatabaseQueue {
-  static var appDatabase: DatabaseQueue {
+extension DatabaseWriter where Self == DatabaseQueue {
+  static var appDatabase: Self {
     let path = URL.documentsDirectory.appending(component: "db.sqlite").path()
     print("open", path)
     var configuration = Configuration()
@@ -85,7 +85,8 @@ extension DatabaseQueue {
       }
     }
     let databaseQueue: DatabaseQueue
-    if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == nil {
+    @Dependency(\.context) var context
+    if context == .live {
       databaseQueue = try! DatabaseQueue(path: path, configuration: configuration)
     } else {
       databaseQueue = try! DatabaseQueue(configuration: configuration)

--- a/Examples/GRDBDemo/Schema.swift
+++ b/Examples/GRDBDemo/Schema.swift
@@ -47,7 +47,7 @@ extension DatabaseWriter {
 
 enum PlayerOrder: String { case name, isInjured }
 
-extension SharedReaderKey where Self == GRDBQueryKey<PlayersRequest>.Default {
+extension SharedReaderKey where Self == GRDBQueryKey<[Player]>.Default {
   static func players(order: PlayerOrder = .name) -> Self {
     Self[
       .grdbQuery(PlayersRequest(order: order), animation: .default),


### PR DESCRIPTION
Making keys generic over their value makes it easier to define extensions for type-safe keys and defaults. It introduces an existential, but it shouldn't be a big performance hit.