### PR TITLE
Revert "Reduce `Shared.init` overloads (#20)"

### DIFF
--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -61,11 +61,12 @@ extension Shared {
   ///     shared key.
   ///   - key: A shared key associated with the shared reference. It is responsible for loading
   ///     and saving the shared reference's value from some external source.
+  @_disfavoredOverload
   public init(
     wrappedValue: @autoclosure () -> Value,
     _ key: _SharedKeyDefault<some SharedKey<Value>>
   ) {
-    self.init(wrappedValue: wrappedValue(), key.base)
+    self.init(wrappedValue: wrappedValue(), key)
   }
 
   /// Creates a shared reference to a value using a shared key.

--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -54,6 +54,20 @@ extension Shared {
     self.init(wrappedValue: key.defaultValue(), key)
   }
 
+  /// Creates a shared reference to a value using a shared key by overriding its default value.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default value that is used when no value can be returned from the
+  ///     shared key.
+  ///   - key: A shared key associated with the shared reference. It is responsible for loading
+  ///     and saving the shared reference's value from some external source.
+  public init(
+    wrappedValue: @autoclosure () -> Value,
+    _ key: _SharedKeyDefault<some SharedKey<Value>>
+  ) {
+    self.init(wrappedValue: wrappedValue(), key.base)
+  }
+
   /// Creates a shared reference to a value using a shared key.
   ///
   /// If the given shared key cannot load a value, an error is thrown. For a non-throwing

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -112,11 +112,12 @@ extension SharedReader {
   ///     shared key.
   ///   - key: A shared key associated with the shared reference. It is responsible for loading
   ///     and saving the shared reference's value from some external source.
+  @_disfavoredOverload
   public init(
     wrappedValue: @autoclosure () -> Value,
     _ key: _SharedKeyDefault<some SharedReaderKey<Value>>
   ) {
-    self.init(wrappedValue: wrappedValue(), key.base)
+    self.init(wrappedValue: wrappedValue(), key)
   }
 
   @_disfavoredOverload
@@ -125,7 +126,7 @@ extension SharedReader {
     wrappedValue: @autoclosure () -> Value,
     _ key: _SharedKeyDefault<some SharedKey<Value>>
   ) {
-    self.init(wrappedValue: wrappedValue(), key.base)
+    self.init(wrappedValue: wrappedValue(), key)
   }
 
   /// Creates a shared reference to a read-only value using a shared key.

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -104,6 +104,30 @@ extension SharedReader {
     self.init(wrappedValue: key.defaultValue(), key)
   }
 
+  /// Creates a shared reference to a read-only value using a shared key by overriding its
+  /// default value.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: A default value that is used when no value can be returned from the
+  ///     shared key.
+  ///   - key: A shared key associated with the shared reference. It is responsible for loading
+  ///     and saving the shared reference's value from some external source.
+  public init(
+    wrappedValue: @autoclosure () -> Value,
+    _ key: _SharedKeyDefault<some SharedReaderKey<Value>>
+  ) {
+    self.init(wrappedValue: wrappedValue(), key.base)
+  }
+
+  @_disfavoredOverload
+  @_documentation(visibility: private)
+  public init(
+    wrappedValue: @autoclosure () -> Value,
+    _ key: _SharedKeyDefault<some SharedKey<Value>>
+  ) {
+    self.init(wrappedValue: wrappedValue(), key.base)
+  }
+
   /// Creates a shared reference to a read-only value using a shared key.
   ///
   /// If the given shared key cannot load a value, an error is thrown. For a non-throwing

--- a/Tests/SharingTests/CompileTimeTests.swift
+++ b/Tests/SharingTests/CompileTimeTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import IdentifiedCollections
+import Sharing
+
+private struct Item: Identifiable {
+  let id = UUID()
+}
+
+extension SharedReaderKey where Self == InMemoryKey<IdentifiedArrayOf<Item>>.Default {
+  fileprivate static var items: Self {
+    Self[.inMemory("items"), default: []]
+  }
+}
+
+func test() {
+  do {
+    @Shared(.items) var items = []
+  }
+  do {
+    @SharedReader(.items) var items = []
+  }
+}

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -171,6 +171,39 @@ import Testing
       #expect(SharedReader($count).description == #"SharedReader<Int>(.appStorage("count"))"#)
     }
 
+    @Test func defaultDescription() {
+      do {
+        @Shared(AppStorageKey.Default[.appStorage("count"), default: 0]) var count
+
+        #expect(
+          $count.description == """
+            Shared<Int>(AppStorageKey<Int>.Default[.appStorage("count"), default: 0])
+            """
+        )
+
+        #expect(
+          SharedReader($count).description == """
+            SharedReader<Int>(AppStorageKey<Int>.Default[.appStorage("count"), default: 0])
+            """
+        )
+      }
+      do {
+        @Shared(AppStorageKey.Default[.appStorage("count"), default: 0]) var count = 0
+
+        #expect(
+          $count.description == """
+            Shared<Int>(AppStorageKey<Int>.Default[.appStorage("count"), default: 0])
+            """
+        )
+
+        #expect(
+          SharedReader($count).description == """
+            SharedReader<Int>(AppStorageKey<Int>.Default[.appStorage("count"), default: 0])
+            """
+        )
+      }
+    }
+
     @Test func fileStorageDescription() {
       @Shared(.fileStorage(URL(filePath: "/"))) var count = 0
 


### PR DESCRIPTION
This reverts commit 4ee963a684d0c02beb28fa503ec37851711394c6.

While these overloads seem unnecessary, they do work around a type inference bug in Swift, which means the original PR unintentionally broke the SyncUps demo:

```swift
@Shared(.syncUps) var syncUps = []  // 🛑
```

> Cannot convert value of type '[SyncUp]' to expected argument type 'IdentifiedArray<Tagged<SyncUp, UUID>, SyncUp>'

I've also pushed a compile-time test for the behavior.