### PR TITLE
Lock access to persistent reference values

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -193,7 +193,8 @@ final class _PersistentReference<Key: SharedReaderKey>:
 
   func load() {
     withMutation(keyPath: \.value) {
-      lock.withLock { value = key.load(initialValue: nil) ?? value }
+      let newValue = key.load(initialValue: nil)
+      lock.withLock { value = newValue ?? value }
     }
   }
 

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -192,9 +192,10 @@ final class _PersistentReference<Key: SharedReaderKey>:
   }
 
   func load() {
+    guard let newValue = key.load(initialValue: nil)
+    else { return }
     withMutation(keyPath: \.value) {
-      let newValue = key.load(initialValue: nil)
-      lock.withLock { value = newValue ?? value }
+      lock.withLock { value = newValue }
     }
   }
 

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -193,7 +193,7 @@ final class _PersistentReference<Key: SharedReaderKey>:
 
   func load() {
     withMutation(keyPath: \.value) {
-      value = key.load(initialValue: nil) ?? value
+      lock.withLock { value = key.load(initialValue: nil) ?? value }
     }
   }
 
@@ -289,7 +289,7 @@ extension _PersistentReference: MutableReference, Equatable where Key: SharedKey
   }
 
   func save() {
-    key.save(value, immediately: true)
+    key.save(lock.withLock { value }, immediately: true)
   }
 
   static func == (lhs: _PersistentReference, rhs: _PersistentReference) -> Bool {


### PR DESCRIPTION
Fixing a few unlocked accesses I noticed.