### PR TITLE
`Shared(require:)` should throw errors with default shared keys

### DIFF
--- a/Sources/Sharing/SharedKeys/DefaultKey.swift
+++ b/Sources/Sharing/SharedKeys/DefaultKey.swift
@@ -46,7 +46,7 @@ public struct _SharedKeyDefault<Base: SharedReaderKey>: SharedReaderKey {
   }
 
   public func load(initialValue: Base.Value?) -> Base.Value? {
-    base.load(initialValue: initialValue ?? defaultValue())
+    base.load(initialValue: initialValue)
   }
 
   public func subscribe(

--- a/Tests/SharingTests/DefaultTests.swift
+++ b/Tests/SharingTests/DefaultTests.swift
@@ -84,6 +84,12 @@ import Testing
       #expect(isOn == true)
     }
   }
+
+  @Test func requireShouldThrow() {
+    withKnownIssue {
+      _ = try Shared(require: .isOn)
+    }
+  }
 }
 
 extension SharedReaderKey where Self == InMemoryKey<Bool>.Default {


### PR DESCRIPTION
We were coalescing to the default value, which means it never threw, but `require: .file` should always mean that the file exists.