### PR TITLE
`_SharedKeyDefault<some SharedKey>` → `(some SharedKey).Default`

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -339,10 +339,6 @@ final class _ManagedReference<Key: SharedReaderKey>: Reference, Observable {
 }
 
 extension _ManagedReference: MutableReference, Equatable where Key: SharedKey {
-  var wrappedValue: Key.Value {
-    base.wrappedValue
-  }
-
   var snapshot: Key.Value? {
     base.snapshot
   }

--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -50,7 +50,7 @@ extension Shared {
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
-  public init(_ key: _SharedKeyDefault<some SharedKey<Value>>) {
+  public init(_ key: (some SharedKey<Value>).Default) {
     self.init(wrappedValue: key.defaultValue(), key)
   }
 
@@ -64,7 +64,7 @@ extension Shared {
   @_disfavoredOverload
   public init(
     wrappedValue: @autoclosure () -> Value,
-    _ key: _SharedKeyDefault<some SharedKey<Value>>
+    _ key: (some SharedKey<Value>).Default
   ) {
     self.init(wrappedValue: wrappedValue(), key)
   }

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -94,13 +94,13 @@ extension SharedReader {
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
-  public init(_ key: _SharedKeyDefault<some SharedReaderKey<Value>>) {
+  public init(_ key: (some SharedReaderKey<Value>).Default) {
     self.init(wrappedValue: key.defaultValue(), key)
   }
 
   @_disfavoredOverload
   @_documentation(visibility: private)
-  public init(_ key: _SharedKeyDefault<some SharedKey<Value>>) {
+  public init(_ key: (some SharedKey<Value>).Default) {
     self.init(wrappedValue: key.defaultValue(), key)
   }
 
@@ -115,7 +115,7 @@ extension SharedReader {
   @_disfavoredOverload
   public init(
     wrappedValue: @autoclosure () -> Value,
-    _ key: _SharedKeyDefault<some SharedReaderKey<Value>>
+    _ key: (some SharedReaderKey<Value>).Default
   ) {
     self.init(wrappedValue: wrappedValue(), key)
   }
@@ -124,7 +124,7 @@ extension SharedReader {
   @_documentation(visibility: private)
   public init(
     wrappedValue: @autoclosure () -> Value,
-    _ key: _SharedKeyDefault<some SharedKey<Value>>
+    _ key: (some SharedKey<Value>).Default
   ) {
     self.init(wrappedValue: wrappedValue(), key)
   }


### PR DESCRIPTION
Small refactor/cleanup so long as older Swift compilers work with it.