### PR TITLE
Add documentation about the force unwrap on a custom UserDefaults init.

### DIFF
--- a/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
@@ -39,8 +39,6 @@ for persisting your state. If you want to use a different user defaults, you can
 ```
 
 That will make it so that all `@Shared(.appStorage)` instances use your custom user defaults.
-The force unwrap on the `suiteName:` initializer will work if you do not use your app's main
-bundle identifier or globalDomain.
 
 In previews `@Shared` will use a temporary, ephemeral user defaults so that each run of the preview
 gets a clean slate. This makes it so that previews do not mutate each other's storage and allows

--- a/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
@@ -31,7 +31,7 @@ for persisting your state. If you want to use a different user defaults, you can
 @main struct EntryPoint: App {
   init() {
     prepareDependencies {
-      $0.defaultAppStorage = UserDefaults(suiteName: "co.pointfree.suite")
+      $0.defaultAppStorage = UserDefaults(suiteName: "co.pointfree.suite")!
     }
   }
   // ...
@@ -39,6 +39,8 @@ for persisting your state. If you want to use a different user defaults, you can
 ```
 
 That will make it so that all `@Shared(.appStorage)` instances use your custom user defaults.
+The force unwrap on the `suiteName:` initializer will work if you do not use your app's main
+bundle identifier or globalDomain.
 
 In previews `@Shared` will use a temporary, ephemeral user defaults so that each run of the preview
 gets a clean slate. This makes it so that previews do not mutate each other's storage and allows


### PR DESCRIPTION
Found some link warnings during the documentation build and I do not know docc enough to repair them. They were on main when I forked. I will leave my fork branch open if you know how to fix them.

/swift-sharing/Sources/Sharing/Documentation.docc/Extensions/Shared.md:41:26 'appStorage(_:)-45ltk' doesn't exist at '/Sharing/SharedReaderKey'
