### PR TITLE
Persist first `.inMemory` default

### DIFF
--- a/Sources/Sharing/SharedKeys/InMemoryKey.swift
+++ b/Sources/Sharing/SharedKeys/InMemoryKey.swift
@@ -41,7 +41,7 @@ public struct InMemoryKey<Value: Sendable>: SharedKey {
     InMemoryKeyID(key: self.key, store: self.store)
   }
   public func load(initialValue: Value?) -> Value? {
-    store.values[key] as? Value ?? initialValue
+    store.values[key, default: initialValue] as? Value
   }
   public func subscribe(
     initialValue: Value?,
@@ -76,6 +76,13 @@ public struct InMemoryStorage: Hashable, Sendable {
     subscript(key: String) -> (any Sendable)? {
       get { storage.withLock { $0[key] } }
       set { storage.withLock { $0[key] = newValue } }
+    }
+
+    subscript(key: String, default defaultValue: (any Sendable)?) -> (any Sendable)? {
+      storage.withLock {
+        $0[key] = $0[key] ?? defaultValue
+        return $0[key]
+      }
     }
   }
 }

--- a/Tests/SharingTests/InMemoryTests.swift
+++ b/Tests/SharingTests/InMemoryTests.swift
@@ -49,4 +49,14 @@ import Testing
     }
     .value
   }
+
+  @Test func `default`() {
+    do {
+      @SharedReader(.inMemory("count")) var count = 10
+    }
+    do {
+      @SharedReader(.inMemory("count")) var count = 0
+      #expect(count == 10)
+    }
+  }
 }


### PR DESCRIPTION
Currently, if you initialize an `.inMemory` key with a default, this default is lost unless the shared is written to.