### PR TITLE
Fix typo in documentation: “must careful” → “must be careful”

### DIFF
--- a/Sources/Sharing/Documentation.docc/Articles/Testing.md
+++ b/Sources/Sharing/Documentation.docc/Articles/Testing.md
@@ -51,7 +51,7 @@ interact with a global store of data, they do so in a way that is quarantined fr
 
 ### Testing when using custom persistence strategies
 
-When creating your own custom persistence strategies you must careful to do so in a style that
+When creating your own custom persistence strategies you must be careful to do so in a style that
 is amenable to testing. For example, the ``SharedReaderKey/appStorage(_:store:)-45ltk`` persistence
 strategy that comes with the library uses a ``Dependencies/DependencyValues/defaultAppStorage``
 dependency so that one can inject a custom `UserDefaults` in order to execute in a controlled


### PR DESCRIPTION
Corrected a typo in the documentation. 
Changed “must careful to” to “must be careful to” for improved clarity and grammatical accuracy.