### PR TITLE
Use `prepareDependencies` for previews

### DIFF
--- a/Examples/CaseStudies/InteractionWithAppStorageView.swift
+++ b/Examples/CaseStudies/InteractionWithAppStorageView.swift
@@ -57,7 +57,8 @@ struct InteractionWithAppStorageView: SwiftUICaseStudy {
   }
 }
 
-#Preview("Standard user defaults", traits: .dependency(\.defaultAppStorage, .standard)) {
+#Preview("Standard user defaults") {
+  let _ = prepareDependencies { $0.defaultAppStorage = .standard }
   NavigationStack {
     CaseStudyView {
       InteractionWithAppStorageView()
@@ -65,14 +66,10 @@ struct InteractionWithAppStorageView: SwiftUICaseStudy {
   }
 }
 
-#Preview(
-  "Quarantined user defaults",
-  traits: .dependencies {
-    $0.defaultAppStorage = UserDefaults(
-      suiteName: "\(NSTemporaryDirectory())co.pointfree.Sharing.\(UUID().uuidString)"
-    )!
-  }
-) {
+#Preview("Quarantined user defaults") {
+  let _ = UserDefaults(
+    suiteName: "\(NSTemporaryDirectory())co.pointfree.Sharing.\(UUID().uuidString)"
+  )!
   @Dependency(\.defaultAppStorage) var store
   NavigationStack {
     CaseStudyView {

--- a/Examples/GRDBDemo/PlayersView.swift
+++ b/Examples/GRDBDemo/PlayersView.swift
@@ -150,14 +150,14 @@ struct AddPlayerView: View {
   }
 }
 
-#Preview(
-  traits: .dependency(\.defaultDatabase, .appDatabase)
-) {
-  @Dependency(\.defaultDatabase) var database
-  let _ = try! database.write { db in
-    for index in 0...9 {
-      _ = try Player(name: "Blob \(index)", isInjured: index.isMultiple(of: 3))
-        .inserted(db)
+#Preview {
+  let _ = prepareDependencies {
+    $0.defaultDatabase = .appDatabase
+    let _ = try! $0.defaultDatabase.write { db in
+      for index in 0...9 {
+        _ = try Player(name: "Blob \(index)", isInjured: index.isMultiple(of: 3))
+          .inserted(db)
+      }
     }
   }
   PlayersView()

--- a/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
@@ -43,12 +43,11 @@ That will make it so that all `@Shared(.appStorage)` instances use your custom u
 In previews `@Shared` will use a temporary, ephemeral user defaults so that each run of the preview
 gets a clean slate. This makes it so that previews do not mutate each other's storage and allows
 you to fully control how your previews behave. If you want to use the `standard` user defaults
-in previews you can use the `dependency` preview trait:
+in previews you can use `prepareDependencies`:
 
 ```swift
-#Preview(
-  traits: .dependency(\.defaultAppStorage, .standard)
-) {
+#Preview {
+  let _ = prepareDependencies { $0.defaultAppStorage = .standard }
   // ...
 }
 ```
@@ -56,11 +55,11 @@ in previews you can use the `dependency` preview trait:
 And finally, in tests `@Shared` will also use a temporary, ephemeral user defaults. This makes it
 so that each test runs in a sandboxed environment that does not interfere with other tests or the 
 simulator. A benefit of this is that your tests can pass deterministically and tests can be run
-in parallel. If you want to use the `standard` user defaults in tests you can use the 
-`dependency` test trait:
+in parallel. If you want to use the `standard` user defaults in tests you can use the `dependency`
+test trait:
 
 ```swift
-#Test(.dependency(\.defaultAppStorage, .standard)) 
+@Test(.dependency(\.defaultAppStorage, .standard))
 func basics() {
   // ...
 }

--- a/Sources/Sharing/Documentation.docc/Extensions/FileStorageKey.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/FileStorageKey.md
@@ -38,13 +38,12 @@ file system. This makes it possible for previews and tests to operate in their o
 environment so that changes made to files do not spill over to other previews or tests, or the
 simulator. It also allows your tests to pass deterministically and for tests to be run in parallel.
 
-If you really do want to use the live file system in your previews, you can use the `dependency`
-preview trait:
+If you really do want to use the live file system in your previews, you can use
+`prepareDependencies`:
 
 ```swift
-#Preview(
-  traits: .dependency(\.defaultFileSystem, .inMemory)
-) {
+#Preview {
+  let _ = prepareDependencies { $0.defaultFileSystem = .inMemory }
   // ...
 }
 ```
@@ -52,7 +51,7 @@ preview trait:
 And if you want to use the live file system in your tests you can use the `dependency` test trait:
 
 ```swift
-#Test(.dependency(\.defaultFileStorage, .inMemory)) 
+@Test(.dependency(\.defaultFileStorage, .inMemory))
 func basics() {
   // ...
 }


### PR DESCRIPTION
The `dependency` preview trait unfortunately bleeds across multiple previews in the same file, so we are deprecating it. We should prefer documenting a method of overriding dependencies that doesn't have this gotcha.