### PR TITLE
Don't include unavailable setter in Swift 5.9.

### DIFF
--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -102,6 +102,7 @@ public struct Shared<Value> {
   ///   }
   /// }
   /// ```
+  #if compiler(>=6)
   public var wrappedValue: Value {
     get {
       @Dependency(\.snapshots) var snapshots
@@ -120,6 +121,16 @@ public struct Shared<Value> {
       withLock { $0 = newValue }
     }
   }
+  #else
+  public var wrappedValue: Value {
+    @Dependency(\.snapshots) var snapshots
+    if snapshots.isAsserting {
+      return reference.snapshot ?? reference.wrappedValue
+    } else {
+      return reference.wrappedValue
+    }
+  }
+  #endif
 
   /// Perform an operation on shared state with isolated access to the underlying value.
   /// 


### PR DESCRIPTION
Addresses #63.

There seems to be a bug in Swift <=5.10 where the unavailable setter on `Shared.wrappedValue` makes even the getter unavailable when using dynamic member lookup with subscripts:

```swift
// Swift <=5.10
func foo() -> Int {
  @Shared(.inMemory("favorites")) var favorites = [42]
  return favorites[0]  // 🛑 Unavailable setter
}
```

You can reproduce this with any subscript that has a setter. The solution is to just omit the unavailable setter in Swift <=5.10.

This bug is still present in Swift 6, but to a lesser degree. If you access through the subscript without assign, Swift thinks we are invoking the setter somehow:

```swift
// Swift >=6
func foo() {
  @Shared(.inMemory("favorites")) var favorites = [42]
  favorites[0]  // 🛑 Unavailable setter
}
```

But since there is no real world use case for doing something like this I think we can live with it.