### PR TITLE
Swift 5.9 fixes/CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,17 @@ jobs:
 
       - name: Build
         run: swift build --swift-sdk wasm32-unknown-wasi -Xlinker -z -Xlinker stack-size=$((1024 * 1024))
+
+  compatibility:
+    name: Compatibility
+    strategy:
+      matrix:
+        xcode: ['15.2']
+        config: ['debug', 'release']
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Run ${{ matrix.config }} tests
+        run: swift test -c ${{ matrix.config }}


### PR DESCRIPTION
Since the package supports 5.9, lets ensure we have coverage.