### PR TITLE
1.x: Add version marker modules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,9 +47,5 @@ let package = Package(
       name: "Sharing1",
       path: "Sources/VersionMarkerModules/Sharing1"
     ),
-    .target(
-      name: "Sharing2",
-      path: "Sources/VersionMarkerModules/Sharing2"
-    ),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
     .target(
       name: "Sharing",
       dependencies: [
+        "Sharing1",
         .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
@@ -41,6 +42,14 @@ let package = Package(
       resources: [
         .process("PrivacyInfo.xcprivacy")
       ]
+    ),
+    .target(
+      name: "Sharing1",
+      path: "Sources/VersionMarkerModules/Sharing1"
+    ),
+    .target(
+      name: "Sharing2",
+      path: "Sources/VersionMarkerModules/Sharing2"
     ),
   ]
 )

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -30,6 +30,7 @@ let package = Package(
     .target(
       name: "Sharing",
       dependencies: [
+        "Sharing1",
         .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
@@ -49,6 +50,10 @@ let package = Package(
         .product(name: "DependenciesTestSupport", package: "swift-dependencies"),
       ],
       exclude: ["Sharing.xctestplan"]
+    ),
+    .target(
+      name: "Sharing1",
+      path: "Sources/VersionMarkerModules/Sharing1"
     ),
   ],
   swiftLanguageModes: [.v6]

--- a/Sources/VersionMarkerModules/Sharing1/Empty.swift
+++ b/Sources/VersionMarkerModules/Sharing1/Empty.swift
@@ -1,0 +1,3 @@
+// The 'Sharing1' module is intentionally empty.
+//
+// It serves as an indicator which version of swift-sharing a package is building against.


### PR DESCRIPTION
This adds a `Sharing1` module to the 1.x release branch of Sharing to distinguish from 0.x.