### PR TITLE
2.x: Add version marker modules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,8 @@ let package = Package(
     .target(
       name: "Sharing",
       dependencies: [
+        "Sharing1",
+        "Sharing2",
         .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "Dependencies", package: "swift-dependencies"),
@@ -39,6 +41,14 @@ let package = Package(
       resources: [
         .process("PrivacyInfo.xcprivacy")
       ]
-    )
+    ),
+    .target(
+      name: "Sharing1",
+      path: "Sources/VersionMarkerModules/Sharing1"
+    ),
+    .target(
+      name: "Sharing2",
+      path: "Sources/VersionMarkerModules/Sharing2"
+    ),
   ]
 )

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -29,6 +29,8 @@ let package = Package(
     .target(
       name: "Sharing",
       dependencies: [
+        "Sharing1",
+        "Sharing2",
         .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "Dependencies", package: "swift-dependencies"),
@@ -47,6 +49,14 @@ let package = Package(
         .product(name: "DependenciesTestSupport", package: "swift-dependencies"),
       ],
       exclude: ["Sharing.xctestplan"]
+    ),
+    .target(
+      name: "Sharing1",
+      path: "Sources/VersionMarkerModules/Sharing1"
+    ),
+    .target(
+      name: "Sharing2",
+      path: "Sources/VersionMarkerModules/Sharing2"
     ),
   ],
   swiftLanguageModes: [.v6]

--- a/Sources/VersionMarkerModules/Sharing1/Empty.swift
+++ b/Sources/VersionMarkerModules/Sharing1/Empty.swift
@@ -1,0 +1,3 @@
+// The 'Sharing1' module is intentionally empty.
+//
+// It serves as an indicator which version of swift-sharing a package is building against.

--- a/Sources/VersionMarkerModules/Sharing2/Empty.swift
+++ b/Sources/VersionMarkerModules/Sharing2/Empty.swift
@@ -1,0 +1,3 @@
+// The 'Sharing2' module is intentionally empty.
+//
+// It serves as an indicator which version of swift-sharing a package is building against.


### PR DESCRIPTION
This adds a `Sharing2` version marker module to distinguish from 1.x and 0.x.