### PR TITLE
Rethrow `$shared.load()` errors

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -298,6 +298,7 @@ final class _PersistentReference<Key: SharedReaderKey>:
       }
     } catch {
       loadError = error
+      throw error
     }
   }
 


### PR DESCRIPTION
We currently `do`-`catch` to populate the `loadError`, but don't rethrow the error to the end user. This PR should fix, but let's get a test case in before merging.