### PR TITLE
Add userInitiatedLoadError test to ErrorThrowingTests

### DIFF
--- a/Tests/SharingTests/ErrorThrowingTests.swift
+++ b/Tests/SharingTests/ErrorThrowingTests.swift
@@ -48,6 +48,36 @@ import Testing
       $0.description == "Caught error: LoadError()"
     }
   }
+  
+  @Test func userInitiatedLoadError() async {
+    struct LoadError: Error {}
+    struct Key: Hashable, Sendable, SharedReaderKey {
+      let id = UUID()
+      func load(context: LoadContext<Int>, continuation: LoadContinuation<Int>) {
+        switch context {
+        case .initialValue:
+          continuation.resume(returning: 42)
+        case .userInitiated:
+          continuation.resume(throwing: LoadError())
+        }
+      }
+      func subscribe(
+        context: LoadContext<Int>, subscriber: SharedSubscriber<Int>
+      ) -> SharedSubscription {
+        SharedSubscription {}
+      }
+    }
+    
+    @SharedReader(Key()) var value = 0
+    
+    await withKnownIssue {
+      await #expect(throws: LoadError.self) {
+        try await $value.load()
+      }
+    } matching: {
+      $0.description == "Caught error: LoadError()"
+    }
+  }
 
   @Test func subscribeError() {
     class Key: SharedReaderKey, @unchecked Sendable {


### PR DESCRIPTION
This test confirms a bug that the base branch fixes—on current version, calling `$sharedValue.load()` will not rethrow the underlying error.