### PR TITLE
Depend directly (not transitively) on ConcurrencyExtras

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,9 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.0"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.5.1"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.4.1"),
@@ -32,6 +33,7 @@ let package = Package(
         "Sharing1",
         "Sharing2",
         .product(name: "CombineSchedulers", package: "combine-schedulers"),
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "IdentifiedCollections", package: "swift-identified-collections"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -17,8 +17,9 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.0"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.5.1"),
     .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.4.1"),
@@ -32,6 +33,7 @@ let package = Package(
         "Sharing1",
         "Sharing2",
         .product(name: "CombineSchedulers", package: "combine-schedulers"),
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         .product(name: "IdentifiedCollections", package: "swift-identified-collections"),

--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -414,14 +414,14 @@
             """
           )
         }
-        let previousValue = LockIsolated(context.initialValue)
+        let previousValue = Mutex(context.initialValue)
         let userDefaultsDidChange = NotificationCenter.default.addObserver(
           forName: UserDefaults.didChangeNotification,
           object: store.wrappedValue,
           queue: nil
         ) { _ in
           let newValue = lookupValue(default: context.initialValue)
-          defer { previousValue.withValue { $0 = newValue } }
+          defer { previousValue.withLock { $0 = newValue } }
           func isEqual<T>(_ lhs: T, _ rhs: T) -> Bool? {
             func open<U: Equatable>(_ lhs: U) -> Bool {
               lhs == rhs as? U
@@ -430,7 +430,7 @@
             return open(lhs)
           }
           guard
-            !(isEqual(newValue, previousValue.value) ?? false)
+            !(isEqual(newValue, previousValue.withLock { $0 }) ?? false)
               || (isEqual(newValue, context.initialValue) ?? true)
           else {
             return

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -117,9 +117,9 @@
     public func subscribe(
       context _: LoadContext<Value>, subscriber: SharedSubscriber<Value>
     ) -> SharedSubscription {
-      let cancellable = LockIsolated<SharedSubscription?>(nil)
+      let cancellable = Mutex<SharedSubscription?>(nil)
       @Sendable func setUpSources() {
-        cancellable.withValue { [weak self] in
+        cancellable.withLock { [weak self] in
           $0?.cancel()
           guard let self else { return }
           do {
@@ -168,7 +168,7 @@
       }
       setUpSources()
       return SharedSubscription {
-        cancellable.withValue { $0?.cancel() }
+        cancellable.withLock { $0?.cancel() }
       }
     }
 


### PR DESCRIPTION
We use `LockIsolated` in `FileStorageKey` but don't depend directly on the library.