### PR TITLE
Public init

### DIFF
--- a/Sources/Sharing/SharedContinuations.swift
+++ b/Sources/Sharing/SharedContinuations.swift
@@ -16,7 +16,7 @@ import IssueReporting
 public struct LoadContinuation<Value>: Sendable {
   private let box: ContinuationBox<Value>
 
-  package init(
+  public init(
     _ description: @autoclosure @escaping @Sendable () -> String = "",
     callback: @escaping @Sendable (Result<Value?, any Error>) -> Void
   ) {
@@ -68,7 +68,7 @@ public struct LoadContinuation<Value>: Sendable {
 public struct SharedSubscriber<Value>: Sendable {
   let callback: @Sendable (Result<Value?, any Error>) -> Void
 
-  package init(callback: @escaping @Sendable (Result<Value?, any Error>) -> Void) {
+  public init(callback: @escaping @Sendable (Result<Value?, any Error>) -> Void) {
     self.callback = callback
   }
 
@@ -158,7 +158,7 @@ public struct SharedSubscription: Sendable {
 public struct SaveContinuation: Sendable {
   private let box: ContinuationBox<Never>
 
-  package init(
+  public init(
     _ description: @autoclosure @escaping @Sendable () -> String = "",
     callback: @escaping @Sendable (Result<Never?, any Error>) -> Void
   ) {


### PR DESCRIPTION
Use public init instead of package init to allow more customizations 

E.g. I would like to add a Codable extension for Shared AppStorage 

```swift
extension SharedReaderKey {
    public static func appStorage<Value: Codable & Sendable>(_ key: String, store: UserDefaults? = nil) -> Self
    where Self == CodableAppStorageKey<Value, AppStorageKey<Data?>> {
      CodableAppStorageKey(appStorageKey: .appStorage(key, store: store))
    }
}

public struct CodableAppStorageKey<Value: Codable & Sendable, UnderlyingKey: SharedKey>: SharedKey where UnderlyingKey.Value == Data? {
  let appStorageKey: UnderlyingKey

  public var id: some Hashable {
    [appStorageKey.id as AnyHashable, "CodableAppStorageKey"]
  }

  public func load(context: LoadContext<Value>, continuation: LoadContinuation<Value>) {
    appStorageKey.load(
      context: context.map { try? JSONEncoder().encode($0) },
      continuation: .init { result in
        continuation.resume(with: result.map { $0?.flatMap {
          try? JSONDecoder().decode(Value.self, from: $0)
        }})
      }
    )
  }

  public func save(_ value: Value, context: SaveContext, continuation: SaveContinuation) {
    let value = try? JSONEncoder().encode(value)
    appStorageKey.save(value, context: context, continuation: continuation)
  }

  public func subscribe(context: LoadContext<Value>, subscriber: SharedSubscriber<Value>) -> SharedSubscription {
    appStorageKey.subscribe(
      context: context.map { try? JSONEncoder().encode($0) },
      subscriber: .init { result in
        subscriber.yield(with: result.map { $0?.flatMap {
          try? JSONDecoder().decode(Value.self, from: $0)
        }})
      }
    )
  }
}

private extension LoadContext {
  func map<T>(transform: (Value) -> T) -> LoadContext<T> {
    switch self {
    case let .initialValue(initialValue): .initialValue(transform(initialValue))
    case .userInitiated: .userInitiated
    }
  }
}

```