### PR TITLE
Keep publishers alive when swapping out shared keys

### DIFF
--- a/Examples/CaseStudies/GlobalRouter.swift
+++ b/Examples/CaseStudies/GlobalRouter.swift
@@ -32,7 +32,7 @@ struct GlobalRouterView: SwiftUICaseStudy {
           case .plainView:
             PlainView()
           case .observableModel:
-            ViewWithObesrvableModel()
+            ViewWithObservableModel()
           case .viewController:
             ViewController.Representable()
               .navigationTitle(Text("UIKit controller"))
@@ -73,7 +73,8 @@ private struct PlainView: View {
       Text(
         template: """
           This screen holds onto `@Shared(.path)` directly in the view and can mutate it directly.
-          """)
+          """
+      )
       Section {
         Button("Go to plain SwiftUI view") {
           $path.withLock { $0.append(.plainView) }
@@ -90,7 +91,7 @@ private struct PlainView: View {
   }
 }
 
-private struct ViewWithObesrvableModel: View {
+private struct ViewWithObservableModel: View {
   @Observable class Model {
     @ObservationIgnored @Shared(.path) var path
   }

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -1113,7 +1113,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/groue/GRDB.swift";
 			requirement = {
-				branch = GRDB7;
+				branch = v7.0.0.beta.7;
 				kind = branch;
 			};
 		};

--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -1113,8 +1113,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/groue/GRDB.swift";
 			requirement = {
-				branch = v7.0.0.beta.7;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Sharing.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sharing.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "142ead9a500d4bcfaff29b4c108bc1b476a4ac30da68cc5ffc80ccfc33c6861b",
+  "originHash" : "93fc90a93abd8a9df27acd732d59fa0e32ba93563a732bd6e16136537445040e",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "branch" : "GRDB7",
-        "revision" : "3ecb5c54553559217592d21a6d9841becb891b38"
+        "branch" : "v7.0.0-beta.7",
+        "revision" : "bbf39353b5f7c5f5643cb8569ee575a7757ed106"
       }
     },
     {

--- a/Sharing.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sharing.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "branch" : "v7.0.0-beta.7",
-        "revision" : "bbf39353b5f7c5f5643cb8569ee575a7757ed106"
+        "revision" : "4de97e6903d29697caae1179cdef8479c64c2639",
+        "version" : "7.0.0"
       }
     },
     {

--- a/Sources/Sharing/Internal/PassthroughRelay.swift
+++ b/Sources/Sharing/Internal/PassthroughRelay.swift
@@ -124,10 +124,9 @@
         guard case .some = downstream else { return }
         self.demand += demand
         guard let upstream else { return }
-        upstream.lock.withLock {
-          for subscription in upstream._upstreams {
-            subscription.request(.unlimited)
-          }
+        let subscriptions = upstream.lock.withLock { upstream._upstreams }
+        for subscription in subscriptions {
+          subscription.request(.unlimited)
         }
       }
 

--- a/Sources/Sharing/Internal/PassthroughRelay.swift
+++ b/Sources/Sharing/Internal/PassthroughRelay.swift
@@ -2,11 +2,12 @@
   import Combine
   import Foundation
 
-  final class PassthroughRelay<Output>: Publisher {
+  final class PassthroughRelay<Output>: Subject {
     typealias Failure = Never
 
     private let lock: os_unfair_lock_t
-    private var _subscriptions = ContiguousArray<Subscription>()
+    private var _upstreams: [any Combine.Subscription] = []
+    private var _downstreams = ContiguousArray<Subscription>()
 
     init() {
       self.lock = os_unfair_lock_t.allocate(capacity: 1)
@@ -14,26 +15,29 @@
     }
 
     deinit {
+      for subscription in _upstreams {
+        subscription.cancel()
+      }
       lock.deinitialize(count: 1)
       lock.deallocate()
     }
 
     func receive(subscriber: some Subscriber<Output, Never>) {
       let subscription = Subscription(upstream: self, downstream: subscriber)
-      lock.withLock { _subscriptions.append(subscription) }
+      lock.withLock { _downstreams.append(subscription) }
       subscriber.receive(subscription: subscription)
     }
 
     func send(_ value: Output) {
-      for subscription in lock.withLock({ _subscriptions }) {
+      for subscription in lock.withLock({ _downstreams }) {
         subscription.receive(value)
       }
     }
 
     func send(completion: Subscribers.Completion<Never>) {
       let subscriptions = lock.withLock {
-        let subscriptions = _subscriptions
-        _subscriptions.removeAll()
+        let subscriptions = _downstreams
+        _downstreams.removeAll()
         return subscriptions
       }
       for subscription in subscriptions {
@@ -41,11 +45,16 @@
       }
     }
 
+    func send(subscription: any Combine.Subscription) {
+      lock.withLock { _upstreams.append(subscription) }
+      subscription.request(.unlimited)
+    }
+
     private func remove(_ subscription: Subscription) {
       lock.withLock {
-        guard let index = _subscriptions.firstIndex(of: subscription)
+        guard let index = _downstreams.firstIndex(of: subscription)
         else { return }
-        _subscriptions.remove(at: index)
+        _downstreams.remove(at: index)
       }
     }
 
@@ -114,6 +123,12 @@
         defer { lock.unlock() }
         guard case .some = downstream else { return }
         self.demand += demand
+        guard let upstream else { return }
+        upstream.lock.withLock {
+          for subscription in upstream._upstreams {
+            subscription.request(.unlimited)
+          }
+        }
       }
 
       static func == (lhs: Subscription, rhs: Subscription) -> Bool {

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -63,12 +63,6 @@ final class _BoxReference<Value>: MutableReference, Observable, Perceptible, @un
     self.value = wrappedValue
   }
 
-  deinit {
-    #if canImport(Combine)
-      subject.send(completion: .finished)
-    #endif
-  }
-
   var id: ObjectIdentifier { ObjectIdentifier(self) }
 
   var isLoading: Bool {
@@ -226,12 +220,6 @@ final class _PersistentReference<Key: SharedReaderKey>:
       context: context,
       subscriber: SharedSubscriber(callback: callback)
     )
-  }
-
-  deinit {
-    #if canImport(Combine)
-      subject.send(completion: .finished)
-    #endif
   }
 
   var id: ObjectIdentifier { ObjectIdentifier(self) }

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -179,7 +179,7 @@ final class _PersistentReference<Key: SharedReaderKey>:
     private let subject = PassthroughRelay<Value>()
 
     var publisher: any Publisher<Key.Value, Never> {
-      subject.prepend(lock.withLock { value })
+      SharedPublisherLocals.isLoading ? subject : subject.prepend(lock.withLock { value })
     }
   #else
     private var value: Key.Value

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -16,7 +16,7 @@ import PerceptionCore
 @dynamicMemberLookup
 @propertyWrapper
 public struct Shared<Value> {
-  private let box: Box
+  let box: Box
   #if canImport(SwiftUI)
     @State private var generation = 0
   #endif
@@ -337,11 +337,15 @@ public struct Shared<Value> {
     reference.saveError
   }
 
-  private final class Box: @unchecked Sendable {
+  final class Box: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var _reference: any MutableReference<Value>
+    #if canImport(Combine)
+      let subject = PassthroughRelay<Value>()
+      private var subjectCancellable: AnyCancellable
+    #endif
     #if canImport(SwiftUI)
-      private var cancellable: AnyCancellable?
+      private var swiftUICancellable: AnyCancellable?
     #endif
     var reference: any MutableReference<Value> {
       _read {
@@ -353,25 +357,36 @@ public struct Shared<Value> {
         lock.lock()
         defer { lock.unlock() }
         yield &_reference
+        #if canImport(Combine)
+          subjectCancellable = _reference.publisher.subscribe(subject)
+        #endif
       }
       set {
-        lock.withLock { _reference = newValue }
+        lock.withLock {
+          _reference = newValue
+          #if canImport(Combine)
+            subjectCancellable = _reference.publisher.subscribe(subject)
+          #endif
+        }
       }
     }
     init(_ reference: any MutableReference<Value>) {
       self._reference = reference
+      #if canImport(Combine)
+        subjectCancellable = _reference.publisher.subscribe(subject)
+      #endif
+    }
+    deinit {
+      #if canImport(Combine)
+        subject.send(completion: .finished)
+      #endif
     }
     #if canImport(SwiftUI)
       func subscribe(state: State<Int>) {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }
         _ = state.wrappedValue
-        func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
-          publisher.dropFirst().sink { _ in
-            state.wrappedValue &+= 1
-          }
-        }
-        let cancellable = open(_reference.publisher)
-        lock.withLock { self.cancellable = cancellable }
+        let cancellable = subject.dropFirst().sink { _ in state.wrappedValue &+= 1 }
+        lock.withLock { swiftUICancellable = cancellable }
       }
     #endif
   }

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -385,7 +385,7 @@ public struct Shared<Value> {
       func subscribe(state: State<Int>) {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }
         _ = state.wrappedValue
-        let cancellable = subject.dropFirst().sink { _ in state.wrappedValue &+= 1 }
+        let cancellable = subject.sink { _ in state.wrappedValue &+= 1 }
         lock.withLock { swiftUICancellable = cancellable }
       }
     #endif

--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -91,13 +91,15 @@ extension Shared {
   public func load(_ key: some SharedKey<Value>) async throws {
     await MainActor.run {
       @Dependency(PersistentReferences.self) var persistentReferences
-      projectedValue = Shared(
-        reference: persistentReferences.value(
-          forKey: key,
-          default: wrappedValue,
-          skipInitialLoad: true
+      SharedPublisherLocals.$isLoading.withValue(true) {
+        projectedValue = Shared(
+          reference: persistentReferences.value(
+            forKey: key,
+            default: wrappedValue,
+            skipInitialLoad: true
+          )
         )
-      )
+      }
     }
     try await load()
   }

--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -99,7 +99,7 @@ extension Shared {
         )
       )
     }
-    try await reference.load()
+    try await load()
   }
 
   /// Creates a shared reference to a value using a shared key by loading it from its external

--- a/Sources/Sharing/SharedPublisher.swift
+++ b/Sources/Sharing/SharedPublisher.swift
@@ -33,7 +33,7 @@
     /// }
     /// ```
     public var publisher: some Publisher<Value, Never> {
-      reference.publisher.eraseToAnyPublisher()
+      box.subject.prepend(wrappedValue)
     }
   }
 #endif

--- a/Sources/Sharing/SharedPublisher.swift
+++ b/Sources/Sharing/SharedPublisher.swift
@@ -15,7 +15,7 @@
     /// }
     /// ```
     public var publisher: some Publisher<Value, Never> {
-      reference.publisher.eraseToAnyPublisher()
+      box.subject.prepend(wrappedValue)
     }
   }
 

--- a/Sources/Sharing/SharedPublisher.swift
+++ b/Sources/Sharing/SharedPublisher.swift
@@ -36,4 +36,8 @@
       box.subject.prepend(wrappedValue)
     }
   }
+
+  enum SharedPublisherLocals {
+    @TaskLocal static var isLoading = false
+  }
 #endif

--- a/Sources/Sharing/SharedPublisher.swift
+++ b/Sources/Sharing/SharedPublisher.swift
@@ -36,8 +36,8 @@
       box.subject.prepend(wrappedValue)
     }
   }
-
-  enum SharedPublisherLocals {
-    @TaskLocal static var isLoading = false
-  }
 #endif
+
+enum SharedPublisherLocals {
+  @TaskLocal static var isLoading = false
+}

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -248,7 +248,7 @@ public struct SharedReader<Value> {
       func subscribe(state: State<Int>) {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }
         _ = state.wrappedValue
-        let cancellable = subject.dropFirst().sink { _ in state.wrappedValue &+= 1 }
+        let cancellable = subject.sink { _ in state.wrappedValue &+= 1 }
         lock.withLock { swiftUICancellable = cancellable }
       }
     #endif

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -15,7 +15,7 @@ import PerceptionCore
 @dynamicMemberLookup
 @propertyWrapper
 public struct SharedReader<Value> {
-  private let box: Box
+  let box: Box
   #if canImport(SwiftUI)
     @State private var generation = 0
   #endif
@@ -200,11 +200,15 @@ public struct SharedReader<Value> {
     reference.loadError
   }
 
-  private final class Box: @unchecked Sendable {
+  final class Box: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var _reference: any Reference<Value>
+    #if canImport(Combine)
+      let subject = PassthroughRelay<Value>()
+      private var subjectCancellable: AnyCancellable
+    #endif
     #if canImport(SwiftUI)
-      private var cancellable: AnyCancellable?
+      private var swiftUICancellable: AnyCancellable?
     #endif
     var reference: any Reference<Value> {
       _read {
@@ -216,25 +220,36 @@ public struct SharedReader<Value> {
         lock.lock()
         defer { lock.unlock() }
         yield &_reference
+        #if canImport(Combine)
+          subjectCancellable = _reference.publisher.subscribe(subject)
+        #endif
       }
       set {
-        lock.withLock { _reference = newValue }
+        lock.withLock {
+          _reference = newValue
+          #if canImport(Combine)
+            subjectCancellable = _reference.publisher.subscribe(subject)
+          #endif
+        }
       }
     }
     init(_ reference: any Reference<Value>) {
       self._reference = reference
+      #if canImport(Combine)
+        subjectCancellable = _reference.publisher.subscribe(subject)
+      #endif
+    }
+    deinit {
+      #if canImport(Combine)
+        subject.send(completion: .finished)
+      #endif
     }
     #if canImport(SwiftUI)
       func subscribe(state: State<Int>) {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }
         _ = state.wrappedValue
-        func open(_ publisher: some Publisher<Value, Never>) -> AnyCancellable {
-          publisher.dropFirst().sink { _ in
-            state.wrappedValue &+= 1
-          }
-        }
-        let cancellable = open(_reference.publisher)
-        lock.withLock { self.cancellable = cancellable }
+        let cancellable = subject.dropFirst().sink { _ in state.wrappedValue &+= 1 }
+        lock.withLock { swiftUICancellable = cancellable }
       }
     #endif
   }

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -165,7 +165,7 @@ extension SharedReader {
         )
       )
     }
-    try await reference.load()
+    try await load()
   }
 
   @_disfavoredOverload

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -157,13 +157,15 @@ extension SharedReader {
   public func load(_ key: some SharedReaderKey<Value>) async throws {
     await MainActor.run {
       @Dependency(PersistentReferences.self) var persistentReferences
-      projectedValue = SharedReader(
-        reference: persistentReferences.value(
-          forKey: key,
-          default: wrappedValue,
-          skipInitialLoad: true
+      SharedPublisherLocals.$isLoading.withValue(true) {
+        projectedValue = SharedReader(
+          reference: persistentReferences.value(
+            forKey: key,
+            default: wrappedValue,
+            skipInitialLoad: true
+          )
         )
-      )
+      }
     }
     try await load()
   }

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -234,7 +234,7 @@
         expectNoDifference(users, [.blob])
 
         try JSONEncoder().encode([User.blobJr]).write(to: .fileURL)
-        try await Task.sleep(nanoseconds: 10_000_000)
+        try await Task.sleep(nanoseconds: 100_000_000)
         expectNoDifference(users, [.blobJr])
       }
 
@@ -246,7 +246,7 @@
         expectNoDifference(users, [.blob])
 
         try FileManager.default.removeItem(at: .fileURL)
-        try await Task.sleep(nanoseconds: 10_000_000)
+        try await Task.sleep(nanoseconds: 100_000_000)
         expectNoDifference(users, [])
       }
 
@@ -259,7 +259,7 @@
           expectNoDifference(users, [.blob])
 
           try FileManager.default.moveItem(at: .fileURL, to: .anotherFileURL)
-          try await Task.sleep(nanoseconds: 10_000_000)
+          try await Task.sleep(nanoseconds: 100_000_000)
           expectNoDifference(users, [])
 
           try FileManager.default.removeItem(at: .fileURL)
@@ -278,11 +278,11 @@
           expectNoDifference(users, [.blob])
 
           try FileManager.default.removeItem(at: .fileURL)
-          try await Task.sleep(nanoseconds: 10_000_000)
+          try await Task.sleep(nanoseconds: 100_000_000)
           expectNoDifference(users, [])
 
           try JSONEncoder().encode([User.blobJr]).write(to: .fileURL)
-          try await Task.sleep(nanoseconds: 10_000_000)
+          try await Task.sleep(nanoseconds: 100_000_000)
           expectNoDifference(users, [.blobJr])
         }
       }

--- a/Tests/SharingTests/PublisherTests.swift
+++ b/Tests/SharingTests/PublisherTests.swift
@@ -78,10 +78,17 @@
       #expect(values.withLock(\.self) == [0, 42, 0])
       $value.withLock { $0 = 1729 }
       #expect(values.withLock(\.self) == [0, 42, 0, 1729])
-      store.set(123, forKey: "count")
+      $count.withLock { $0 = 123 }
       #expect(values.withLock(\.self) == [0, 42, 0, 1729])
       store.set(456, forKey: "anotherCount")
       #expect(values.withLock(\.self) == [0, 42, 0, 1729, 456])
+
+      $value = Shared(wrappedValue: 0, .appStorage("yetAnotherCount"))
+      #expect(values.withLock(\.self) == [0, 42, 0, 1729, 456, 0])
+      $count.withLock { $0 = 456 }
+      #expect(values.withLock(\.self) == [0, 42, 0, 1729, 456, 0])
+      $value.withLock { $0 = 789 }
+      #expect(values.withLock(\.self) == [0, 42, 0, 1729, 456, 0, 789])
     }
 
     @MainActor

--- a/Tests/SharingTests/PublisherTests.swift
+++ b/Tests/SharingTests/PublisherTests.swift
@@ -108,13 +108,56 @@
       #expect(values.withLock(\.self) == [0, 42])
 
       try await $value.load(.appStorage("anotherCount"))
-      #expect(values.withLock(\.self) == [0, 42, 42])
+      #expect(values.withLock(\.self) == [0, 42])
       $value.withLock { $0 = 1729 }
-      #expect(values.withLock(\.self) == [0, 42, 42, 1729])
+      #expect(values.withLock(\.self) == [0, 42, 1729])
       store.set(123, forKey: "count")
-      #expect(values.withLock(\.self) == [0, 42, 42, 1729])
+      #expect(values.withLock(\.self) == [0, 42, 1729])
       store.set(456, forKey: "anotherCount")
-      #expect(values.withLock(\.self) == [0, 42, 42, 1729, 456])
+      #expect(values.withLock(\.self) == [0, 42, 1729, 456])
+    }
+
+    @MainActor
+    @Test func reloadExistingShared() async throws {
+      @Dependency(\.defaultAppStorage) var store
+      @Shared(.appStorage("anotherCount")) var anotherCount = 1729
+      @Shared(.appStorage("count")) var value = 0
+      let values = Mutex<[Int]>([])
+      let cancellable = $value.publisher.sink { @Sendable value in
+        values.withLock {
+          $0.append(value)
+        }
+      }
+      defer { _ = cancellable }
+
+      #expect(values.withLock(\.self) == [0])
+      $value.withLock { $0 = 42 }
+      #expect(values.withLock(\.self) == [0, 42])
+
+      store.set(1729, forKey: "anotherCount")
+      try await $value.load(.appStorage("anotherCount"))
+      #expect(values.withLock(\.self) == [0, 42, 1729])
+    }
+
+    @MainActor
+    @Test func reloadExistingPersistedValue() async throws {
+      @Dependency(\.defaultAppStorage) var store
+      @Shared(.appStorage("count")) var value = 0
+      let values = Mutex<[Int]>([])
+      let cancellable = $value.publisher.sink { @Sendable value in
+        values.withLock {
+          $0.append(value)
+        }
+      }
+      defer { _ = cancellable }
+
+      #expect(values.withLock(\.self) == [0])
+      $value.withLock { $0 = 42 }
+      #expect(values.withLock(\.self) == [0, 42])
+
+      store.set(1729, forKey: "anotherCount")
+      try await $value.load(.appStorage("anotherCount"))
+      #expect(values.withLock(\.self) == [0, 42, 1729])
     }
 
     @MainActor

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -5,6 +5,14 @@ import Sharing
 import Testing
 
 @Suite struct SharedTests {
+  @Test func projectedValue() {
+    @Shared(.inMemory("count")) var count = 0
+    let shared = $count
+
+    $count = Shared(wrappedValue: 42, .inMemory("anotherCount"))
+    #expect(shared.wrappedValue == 42)
+  }
+
   @Suite struct Persistence {
     @Test func laziness() {
       do {


### PR DESCRIPTION
Currently, swapping out a shared property's persistence strategy will terminate all existing publishers associated with the property.

```swift
$shared = Shared(.newKey)
// or
$shared.load(.newKey)
```

While an argument can be made for the behavior, it doesn't seem ideal, and could probably be thought of as a bug. So instead, let's keep the publishers alive by moving the publishing source into the `Shared` wrapper and have it subscribe to new keys as they're assigned.