### PR TITLE
Fix ambiguous initializer in SharedReader with optionals.

### DIFF
--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -101,6 +101,7 @@ extension SharedReader {
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
+  @_disfavoredOverload
   public init<Wrapped>(_ key: some SharedReaderKey<Value>) where Value == Wrapped? {
     self.init(wrappedValue: nil, key)
   }
@@ -108,7 +109,7 @@ extension SharedReader {
   @_disfavoredOverload
   @_documentation(visibility: private)
   public init<Wrapped>(_ key: some SharedKey<Value>) where Value == Wrapped? {
-    self.init(key)
+    self.init(wrappedValue: nil, key)
   }
 
   /// Creates a shared reference to a read-only value using a shared key with a default value.

--- a/Tests/SharingTests/CompileTimeTests.swift
+++ b/Tests/SharingTests/CompileTimeTests.swift
@@ -30,8 +30,20 @@ func testSharedReaderLoadOverload() async throws {
   try await shared.load(.count)
 }
 
+func testSharedReaderKeyWithDefault() {
+  @SharedReader(.count)
+  var count1
+  @Shared(.count) var count2
+}
+
 extension SharedKey where Self == InMemoryKey<Int> {
   fileprivate static var count: Self {
     .inMemory("count")
+  }
+}
+
+extension SharedReaderKey where Self == AppStorageKey<Int?>.Default {
+  public static var count: Self {
+    Self[.appStorage("count"), default: nil]
   }
 }


### PR DESCRIPTION
This came up in [Slack](https://pointfreecommunity.slack.com/archives/C0837DJJFA9/p1738019751770999?thread_ts=1738019715.428849&cid=C0837DJJFA9).