### PR TITLE
Publicize SharedKey.Default's initial value

### DIFF
--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -66,7 +66,7 @@ extension Shared {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
   public init(_ key: (some SharedKey<Value>).Default) {
-    self.init(wrappedValue: key.defaultValue(), key)
+    self.init(wrappedValue: key.defaultValue, key)
   }
 
   /// Creates a shared reference to a value using a shared key by overriding its default value.

--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -66,7 +66,7 @@ extension Shared {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
   public init(_ key: (some SharedKey<Value>).Default) {
-    self.init(wrappedValue: key.defaultValue, key)
+    self.init(wrappedValue: key.initialValue, key)
   }
 
   /// Creates a shared reference to a value using a shared key by overriding its default value.

--- a/Sources/Sharing/SharedKeys/DefaultKey.swift
+++ b/Sources/Sharing/SharedKeys/DefaultKey.swift
@@ -32,6 +32,11 @@ public struct _SharedKeyDefault<Base: SharedReaderKey>: SharedReaderKey {
     base.id
   }
 
+  /// The default value this key was initialized with.
+  public var initialValue: Base.Value {
+    defaultValue()
+  }
+
   /// Wraps an existing shared key in a shared key that provides a default value.
   ///
   /// - Parameters:

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -117,7 +117,7 @@ extension SharedReader {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
   public init(_ key: (some SharedReaderKey<Value>).Default) {
-    self.init(wrappedValue: key.defaultValue(), key)
+    self.init(wrappedValue: key.defaultValue, key)
   }
 
   @_disfavoredOverload

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -117,7 +117,7 @@ extension SharedReader {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
   public init(_ key: (some SharedReaderKey<Value>).Default) {
-    self.init(wrappedValue: key.defaultValue, key)
+    self.init(wrappedValue: key.initialValue, key)
   }
 
   @_disfavoredOverload

--- a/Tests/SharingTests/DefaultTests.swift
+++ b/Tests/SharingTests/DefaultTests.swift
@@ -84,6 +84,10 @@ import Testing
       #expect(isOn == true)
     }
   }
+
+  @Test func initialValue() {
+    #expect(InMemoryKey<Bool>.Default.isOn.initialValue == false)
+  }
 }
 
 extension SharedReaderKey where Self == InMemoryKey<Bool>.Default {


### PR DESCRIPTION
It could be useful to programmatically access the initial value of a shared key.

For example, you could provide the ability to reset a shared value to its default:

```swift
if loadError = $syncUps.loadError {
  Button("Load sample data") {
    $syncUps.withLock {
      $0 = FileStorageKey.Default.syncUps.initialValue
    }
  }
}
```