### PR TITLE
Fix sending default value for inMemoryKey when Value is Optional

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "swift-sharing",
   platforms: [
-    .iOS(.v13),
+    .iOS(.v16),
     .macOS(.v10_15),
     .tvOS(.v13),
     .watchOS(.v6),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -5,6 +5,7 @@ import PackageDescription
 let package = Package(
   name: "swift-sharing",
   platforms: [
+    .iOS(.v13),
     .macOS(.v10_15),
     .tvOS(.v13),
     .watchOS(.v6),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -5,7 +5,6 @@ import PackageDescription
 let package = Package(
   name: "swift-sharing",
   platforms: [
-    .iOS(.v16),
     .macOS(.v10_15),
     .tvOS(.v13),
     .watchOS(.v6),

--- a/Sources/Sharing/SharedKeys/InMemoryKey.swift
+++ b/Sources/Sharing/SharedKeys/InMemoryKey.swift
@@ -45,11 +45,12 @@ public struct InMemoryKey<Value: Sendable>: SharedKey {
     case .initialValue(let initialValue):
       continuation.resume(returning: store.values[key, default: initialValue])
     case .userInitiated:
-      guard let value = store.values[key] as? Value else {
+      switch store.values[key] {
+      case let .some(value as Value):
+        continuation.resume(returning: value)
+      default:
         continuation.resumeReturningInitialValue()
-        return
       }
-      continuation.resume(returning: value)
     }
   }
   public func subscribe(
@@ -93,6 +94,7 @@ public struct InMemoryStorage: Hashable, Sendable {
         case let .some(value as Value):
           return value
         default:
+          storage[key] = defaultValue
           return defaultValue
         }
       }

--- a/Sources/Sharing/SharedKeys/InMemoryKey.swift
+++ b/Sources/Sharing/SharedKeys/InMemoryKey.swift
@@ -89,13 +89,12 @@ public struct InMemoryStorage: Hashable, Sendable {
 
     subscript<Value: Sendable>(key: String, default defaultValue: Value) -> Value {
       storage.withLock { storage in
-        let value =
-          (storage[key] as? Value)
-          ?? {
-            storage[key] = defaultValue
-            return defaultValue
-          }()
-        return value
+        switch (storage[key]) {
+        case let .some(value as Value):
+          return value
+        default:
+          return defaultValue
+        }
       }
     }
   }

--- a/Sources/Sharing/SharedKeys/InMemoryKey.swift
+++ b/Sources/Sharing/SharedKeys/InMemoryKey.swift
@@ -90,7 +90,7 @@ public struct InMemoryStorage: Hashable, Sendable {
 
     subscript<Value: Sendable>(key: String, default defaultValue: Value) -> Value {
       storage.withLock { storage in
-        switch (storage[key]) {
+        switch storage[key] {
         case let .some(value as Value):
           return value
         default:

--- a/Tests/SharingTests/InMemoryTests.swift
+++ b/Tests/SharingTests/InMemoryTests.swift
@@ -65,4 +65,29 @@ import Testing
       throw error
     }
   }
+
+  @Test func optionalDefault() {
+    do {
+      @Shared(.inMemory("count")) var count: Int? = 0
+      #expect(count == 0)
+    }
+
+    do {
+      @Shared(.inMemory("nilCount")) var nilCount: Int? = nil
+      #expect(nilCount == nil)
+    }
+
+    do {
+      @Shared(.inMemory("optionalCount")) var optionalCount: Int?? = .some(0)
+      #expect(optionalCount == .some(0))
+    }
+
+    do {
+      @Shared(.inMemory("nestedOptionalCount")) var nestedOptionalCount: Int?? = .some(.none)
+      #expect(nestedOptionalCount == .some(.none))
+
+      @SharedReader(.inMemory("nestedOptionalCountReader")) var nestedOptionalCountReader: Int?? = .some(.none)
+      #expect(nestedOptionalCountReader == .some(.none))
+    }
+  }
 }

--- a/Tests/SharingTests/InMemoryTests.swift
+++ b/Tests/SharingTests/InMemoryTests.swift
@@ -66,7 +66,7 @@ import Testing
     }
   }
 
-  @Test func optionalDefault() {
+  @Test func optionalDefault() async {
     do {
       @Shared(.inMemory("count")) var count: Int? = 0
       #expect(count == 0)

--- a/Tests/SharingTests/InMemoryTests.swift
+++ b/Tests/SharingTests/InMemoryTests.swift
@@ -92,7 +92,7 @@ import Testing
 
     do {
       await #expect(throws: Error.self) {
-        try await Shared<Int?>(require: .inMemory("count"))
+        try await Shared<Int?>(require: .inMemory("countNotExist"))
       }
     }
   }

--- a/Tests/SharingTests/InMemoryTests.swift
+++ b/Tests/SharingTests/InMemoryTests.swift
@@ -89,5 +89,11 @@ import Testing
       @SharedReader(.inMemory("nestedOptionalCountReader")) var nestedOptionalCountReader: Int?? = .some(.none)
       #expect(nestedOptionalCountReader == .some(.none))
     }
+
+    do {
+      await #expect(throws: Error.self) {
+        try await Shared<Int?>(require: .inMemory("count"))
+      }
+    }
   }
 }


### PR DESCRIPTION
The original implementation had an edge case when `Value` itself was an `Optional` type (e.g., `Int?`). 

In such cases:
- If there is no stored value, the cast `(storage[key] as? Value)` would still succeed (since `nil` matches `Optional<Something>`), bypassing the `defaultValue`.
- This caused `nil` to be treated as the "default" instead of propagating the provided `defaultValue` (e.g., `0` for `Int?`).