### PR TITLE
Fix: Unit Tests Fail on iOS 13 Due to Dependency on iOS 16+ APIs

### DIFF
--- a/Tests/SharingTests/ErrorThrowingTests.swift
+++ b/Tests/SharingTests/ErrorThrowingTests.swift
@@ -241,7 +241,7 @@ import Testing
     #expect($count.loadError != nil)
 
     let task = Task { [$count] in try await $count.load() }
-    try await Task.sleep(for: .seconds(0.1))
+    try await Task.sleep(nanoseconds: 100_000_000)
 
     #expect($count.isLoading)
     #expect($count.loadError != nil)

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -176,7 +176,7 @@
     struct InMemoryFileStorageTests {
       let numbers = FileStorageKey<[Int]>.Default[
         .fileStorage(
-          .documentsDirectory.appending(path: "numbers.json"),
+          URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("numbers.json"),
           decode: { try JSONDecoder().decode([Int].self, from: $0) },
           encode: { try JSONEncoder().encode(Array($0.prefix(2))) }
         ),
@@ -366,7 +366,7 @@
             Dictionary((1...10).map { n in (n, m) }, uniquingKeysWith: { $1 }),
             counts
           )
-          try await Task.sleep(for: .seconds(0.001))
+          try await Task.sleep(nanoseconds: 1_000_000)
         }
       }
 
@@ -378,7 +378,7 @@
             group.addTask { [$counts] in
               for _ in 1...10 {
                 $counts.withLock { $0[0, default: 0] += 1 }
-                try? await Task.sleep(for: .seconds(0.001))
+                try? await Task.sleep(nanoseconds: 1_000_000)
               }
             }
           }

--- a/Tests/SharingTests/IsLoadingTests.swift
+++ b/Tests/SharingTests/IsLoadingTests.swift
@@ -38,7 +38,7 @@ import Testing
     let task = Task {
       $value = try await SharedReader(require: Key(testScheduler: testScheduler))
     }
-    try await Task.sleep(for: .seconds(0.1))
+    try await Task.sleep(nanoseconds: 100_000_000)
     #expect($value.isLoading == false)
     #expect(value == 42)
     _ = { testScheduler.advance() }()
@@ -56,7 +56,7 @@ import Testing
     let task = Task {
       try await $value.load(Key(testScheduler: testScheduler))
     }
-    try await Task.sleep(for: .seconds(0.1))
+    try await Task.sleep(nanoseconds: 100_000_000)
     #expect($value.isLoading == true)
     #expect(value == 42)
     _ = { testScheduler.advance() }()

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -213,7 +213,7 @@ import Testing
     }
 
     @Test func fileStorageDescription() {
-      @Shared(.fileStorage(URL(filePath: "/"))) var count = 0
+      @Shared(.fileStorage(URL(fileURLWithPath: "/"))) var count = 0
 
       #expect($count.description == #"Shared<Int>(.fileStorage(file:///))"#)
     }


### PR DESCRIPTION
The current test suite fails to run on iOS 13 simulators/devices because it uses APIs introduced in iOS 16. PR replaces them with iOS 13 supported versions.