### PR TITLE
Change documentation to use `withDependencies` where needed

### DIFF
--- a/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
@@ -14,10 +14,14 @@ test proves:
 
 ```swift
 @Test func externalWrite() {
-  @Shared(.appStorage("isOn")) var isOn = true
-  #expect(isOn == true)  
-  UserDefaults.standard.set(false, forKey: "isOn")
-  #expect(isOn == false)
+  withDependencies {
+    $0.defaultAppStorage = .liveValue
+  } operation: {
+    @Shared(.appStorage("isOn")) var isOn = true
+    #expect(isOn == true)
+    UserDefaults.standard.set(false, forKey: "isOn")
+    #expect(isOn == false)
+  }
 }
 ```
 

--- a/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/AppStorageKey.md
@@ -13,15 +13,14 @@ the "isOn" key in user defaults will be immediately played back to the `@Shared`
 test proves:
 
 ```swift
-@Test func externalWrite() {
-  withDependencies {
-    $0.defaultAppStorage = .liveValue
-  } operation: {
-    @Shared(.appStorage("isOn")) var isOn = true
-    #expect(isOn == true)
-    UserDefaults.standard.set(false, forKey: "isOn")
-    #expect(isOn == false)
-  }
+@Test(.dependency(\.defaultAppStorage, .liveValue))
+func externalWrite() {
+  UserDefaults.standard.removeObject(forKey: "isOn")
+
+  @Shared(.appStorage("isOn")) var isOn = true
+  #expect(isOn == true)
+  UserDefaults.standard.set(false, forKey: "isOn")
+  #expect(isOn == false)
 }
 ```
 

--- a/Sources/Sharing/Documentation.docc/Extensions/FileStorageKey.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/FileStorageKey.md
@@ -18,11 +18,17 @@ the `@Shared` value, as this test proves:
 
 ```swift
 @Test func externalWrite() throws {
-  let url = URL.temporaryDirectory.appending(component: "is-on.json") 
-  @Shared(.fileStorage(url)) var isOn = true
-  #expect(isOn == true)  
-  try Data("false".utf8).write(to: url)
-  #expect(isOn == false)
+  try withDependencies {
+    $0.defaultFileStorage = .fileSystem
+  } operation: {
+    let url = URL.temporaryDirectory.appending(component: "is-on.json")
+    try? FileManager.default.removeItem(at: url)
+
+    @Shared(.fileStorage(url)) var isOn = true
+    #expect(isOn == true)
+    try Data("false".utf8).write(to: url)
+    #expect(isOn == false)
+  }
 }
 ```
 

--- a/Sources/Sharing/Documentation.docc/Extensions/FileStorageKey.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/FileStorageKey.md
@@ -17,18 +17,15 @@ Further, any change made to the file stored at the URL will also be immediately 
 the `@Shared` value, as this test proves:
 
 ```swift
-@Test func externalWrite() throws {
-  try withDependencies {
-    $0.defaultFileStorage = .fileSystem
-  } operation: {
-    let url = URL.temporaryDirectory.appending(component: "is-on.json")
-    try? FileManager.default.removeItem(at: url)
+@Test(.dependency(\.defaultFileStorage, .fileSystem))
+func externalWrite() throws {
+  let url = URL.temporaryDirectory.appending(component: "is-on.json")
+  try? FileManager.default.removeItem(at: url)
 
-    @Shared(.fileStorage(url)) var isOn = true
-    #expect(isOn == true)
-    try Data("false".utf8).write(to: url)
-    #expect(isOn == false)
-  }
+  @Shared(.fileStorage(url)) var isOn = true
+  #expect(isOn == true)
+  try Data("false".utf8).write(to: url)
+  #expect(isOn == false)
 }
 ```
 


### PR DESCRIPTION
#95 