### PR TITLE
Don't use temp directory for user defaults on iOS <17.

### DIFF
--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -522,11 +522,17 @@
 
   private enum DefaultAppStorageKey: DependencyKey {
     static var testValue: UncheckedSendable<UserDefaults> {
-      UncheckedSendable(
-        UserDefaults(
-          suiteName:
-            "\(NSTemporaryDirectory())co.pointfree.Sharing.\(UUID().uuidString)"
-        )!
+      let suiteName: String
+      // NB: Due to a bug in iOS 16 and lower, UserDefaults does not observe changes when using
+      //     file-based suites. Go back to using temporary directory always when we drop iOS 16
+      //     support.
+      if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10, visionOS 1) {
+        suiteName = "co.pointfree.Sharing.\(UUID().uuidString)"
+      } else {
+        suiteName = "\(NSTemporaryDirectory())co.pointfree.Sharing.\(UUID().uuidString)"
+      }
+      return UncheckedSendable(
+        UserDefaults(suiteName: suiteName)!
       )
     }
     static var previewValue: UncheckedSendable<UserDefaults> {


### PR DESCRIPTION
Fixes #92 