### PR TITLE
Fix existential crash in iOS 15.

### DIFF
--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -401,7 +401,7 @@ extension Shared: CustomStringConvertible {
 extension Shared: Equatable where Value: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     func openLhs<T: MutableReference<Value>>(_ lhsReference: T) -> Bool {
-      NB: iOS <16 does not support casting this existential directly, so we must open it explicitly
+      // NB: iOS <16 does not support casting this existential, so we must open it explicitly
       func openRhs<S: MutableReference<Value>>(_ rhsReference: S) -> Bool {
         lhsReference == rhsReference as? T
       }

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -400,14 +400,14 @@ extension Shared: CustomStringConvertible {
 
 extension Shared: Equatable where Value: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
-    func open<T: MutableReference<Value>>(_ lhsReference: T) -> Bool {
-      func open2<S: MutableReference<Value>>(_ rhsReference: S) -> Bool {
+    func openLhs<T: MutableReference<Value>>(_ lhsReference: T) -> Bool {
+      func openRhs<S: MutableReference<Value>>(_ rhsReference: S) -> Bool {
         lhsReference == rhsReference as? T
       }
-      return open2(rhs.reference)
+      return openRhs(rhs.reference)
     }
     @Dependency(\.snapshots) var snapshots
-    if snapshots.isAsserting, open(lhs.reference) {
+    if snapshots.isAsserting, openLhs(lhs.reference) {
       snapshots.untrack(lhs.reference)
       return lhs.wrappedValue == rhs.reference.wrappedValue
     } else {

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -401,12 +401,14 @@ extension Shared: CustomStringConvertible {
 extension Shared: Equatable where Value: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     func open<T: MutableReference<Value>>(_ lhsReference: T) -> Bool {
-      @Dependency(\.snapshots) var snapshots
-      guard snapshots.isAsserting, lhsReference == rhs.reference as? T else { return false }
-      snapshots.untrack(lhsReference)
-      return true
+      func open2<S: MutableReference<Value>>(_ rhsReference: S) -> Bool {
+        lhsReference == rhsReference as? T
+      }
+      return open2(rhs.reference)
     }
-    if open(lhs.reference) {
+    @Dependency(\.snapshots) var snapshots
+    if snapshots.isAsserting, open(lhs.reference) {
+      snapshots.untrack(lhs.reference)
       return lhs.wrappedValue == rhs.reference.wrappedValue
     } else {
       return lhs.wrappedValue == rhs.wrappedValue

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -401,6 +401,7 @@ extension Shared: CustomStringConvertible {
 extension Shared: Equatable where Value: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     func openLhs<T: MutableReference<Value>>(_ lhsReference: T) -> Bool {
+      NB: iOS <16 does not support casting this existential directly, so we must open it explicitly
       func openRhs<S: MutableReference<Value>>(_ rhsReference: S) -> Bool {
         lhsReference == rhsReference as? T
       }


### PR DESCRIPTION
Fixes #93.

It turns out that Swift does not support casting existentials with primary associated types in iOS <16, and so we have to open the existential and then cast.