### PR TITLE
Retain Shared reference in publisher

### DIFF
--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -376,11 +376,6 @@ public struct Shared<Value> {
         subjectCancellable = _reference.publisher.subscribe(subject)
       #endif
     }
-    deinit {
-      #if canImport(Combine)
-        subject.send(completion: .finished)
-      #endif
-    }
     #if canImport(SwiftUI)
       func subscribe(state: State<Int>) {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }

--- a/Sources/Sharing/SharedPublisher.swift
+++ b/Sources/Sharing/SharedPublisher.swift
@@ -15,7 +15,9 @@
     /// }
     /// ```
     public var publisher: some Publisher<Value, Never> {
-      box.subject.prepend(wrappedValue)
+      box.subject
+        .handleEvents(receiveSubscription: { [box] _ in _ = box })
+        .prepend(wrappedValue)
     }
   }
 
@@ -33,7 +35,9 @@
     /// }
     /// ```
     public var publisher: some Publisher<Value, Never> {
-      box.subject.prepend(wrappedValue)
+      box.subject
+        .handleEvents(receiveSubscription: { [box] _ in _ = box })
+        .prepend(wrappedValue)
     }
   }
 #endif

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -239,11 +239,6 @@ public struct SharedReader<Value> {
         subjectCancellable = _reference.publisher.subscribe(subject)
       #endif
     }
-    deinit {
-      #if canImport(Combine)
-        subject.send(completion: .finished)
-      #endif
-    }
     #if canImport(SwiftUI)
       func subscribe(state: State<Int>) {
         guard #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) else { return }

--- a/Tests/SharingTests/PublisherTests.swift
+++ b/Tests/SharingTests/PublisherTests.swift
@@ -195,7 +195,7 @@
       #expect(didComplete.withLock { $0 })
     }
 
-    @Test func derivedShared() {
+    @Test func retainPublisherInDerivedShared() {
       struct Wrapper {
         var value = 0
       }


### PR DESCRIPTION
In 2.1.1 we fixed a longstanding issue of shared publishers in that they terminated if a shared key was ever swapped out for a new one. But in fixing this we changed the lifetime of the publisher so that it only lives as long as its `@Shared` reference.

This PR explores retaining the reference inside the publisher to ensure the publisher lives for as long as it's subscribed to.