### PR TITLE
Introduce `SharedReader.init(value:)`

### DIFF
--- a/Sources/Sharing/Documentation.docc/Extensions/SharedReader.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/SharedReader.md
@@ -61,7 +61,7 @@ if remoteConfig.isToggleEnabled {
 
 ### Creating a shared reader
 
-- ``constant(_:)``
+- ``init(value:)``
 - ``init(projectedValue:)``
 
 ### Transforming a shared value

--- a/Sources/Sharing/Documentation.docc/Extensions/SharedReaderDeprecations.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/SharedReaderDeprecations.md
@@ -1,0 +1,14 @@
+# Deprecations
+
+Review unsupported shared reader APIs and their replacements.
+
+## Overview
+
+Avoid using deprecated APIs in your app. Select a method to see the replacement that you should use
+instead.
+
+## Topics
+
+### Creating a shared reader
+
+- ``SharedReader/constant``

--- a/Sources/Sharing/Internal/Deprecations.swift
+++ b/Sources/Sharing/Internal/Deprecations.swift
@@ -1,0 +1,15 @@
+// NB: Deprecated after 2.2.0
+
+extension SharedReader {
+  #if compiler(>=6)
+    @available(*, deprecated, message: "Use 'SharedReader(value:)', instead.")
+    public static func constant(_ value: sending Value) -> Self {
+      Self(Shared(value: value))
+    }
+  #else
+    @available(*, deprecated, message: "Use 'SharedReader(value:)', instead.")
+    public static func constant(_ value: Value) -> Self {
+      Self(Shared(value: value))
+    }
+  #endif
+}

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -34,8 +34,7 @@ public struct Shared<Value> {
 
   /// Wraps a value in a shared reference.
   ///
-  /// - Parameters:
-  ///   - value: A value to wrap.
+  /// - Parameter value: A value to wrap.
   #if compiler(>=6)
     public init(value: sending Value) {
       self.init(reference: _BoxReference(wrappedValue: value))

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -31,6 +31,50 @@ public struct SharedReader<Value> {
     self.box = Box(reference)
   }
 
+  /// Wraps a value in a shared reference.
+  ///
+  /// This can be useful for initializing a `SharedReader` with a default value before it is
+  /// configured with a key:
+  ///
+  /// ```swift
+  /// struct ContentView: View {
+  ///   @SharedReader(value: Config()) var config
+  ///
+  ///   var body: some View {
+  ///     VStack {
+  ///       // ...
+  ///     }
+  ///     .task {
+  ///       try await $config.load(.remoteConfig)
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// It can also be useful for providing `SharedReader` values to features in previews and tests:
+  ///
+  /// ```swift
+  /// struct CounterView: View {
+  ///   @SharedReader var count: Int
+  ///   // ...
+  /// }
+  ///
+  /// #Preview {
+  ///   CounterView(count: SharedReader(value: 42))
+  /// }
+  /// ```
+  ///
+  /// - Parameter value: A value to wrap.
+  #if compiler(>=6)
+    public init(value: sending Value) {
+      self.init(reference: _BoxReference(wrappedValue: value))
+    }
+  #else
+    public init(value: Value) {
+      self.init(reference: _BoxReference(wrappedValue: value))
+    }
+  #endif
+
   /// Creates a read-only shared reference from a shared reference.
   ///
   /// - Parameter base: A shared reference.
@@ -81,30 +125,6 @@ public struct SharedReader<Value> {
   public init(projectedValue: Self) {
     self = projectedValue
   }
-
-  /// Constructs a read-only shared value that remains constant.
-  ///
-  /// This can be useful for providing ``SharedReader`` values to features in previews and tests:
-  ///
-  /// ```swift
-  /// struct CounterView: View {
-  ///   @SharedReader var count: Int
-  ///   // ...
-  /// }
-  ///
-  /// #Preview {
-  ///   CounterView(count: .constant(42))
-  /// )
-  /// ```
-  #if compiler(>=6)
-    public static func constant(_ value: sending Value) -> Self {
-      Self(Shared(value: value))
-    }
-  #else
-    public static func constant(_ value: Value) -> Self {
-      Self(Shared(value: value))
-    }
-  #endif
 
   /// The underlying value referenced by the shared variable.
   ///


### PR DESCRIPTION
The `.constant` helper was inspired by SwiftUI's `Binding.constant`, and was useful for mocking data in previews, but it's not usable in property wrapper declarations, forcing an additional step to initialize this data:

```swift
struct ContentView: View {
  @SharedReader var config: Config

  init() {
    _config = .constant(Config())
  }

  var body: some View {
    VStack {
      // ...
    }
    .task {
      try await $config.load(.remoteConfig)
    }
  }
}
```

Instead, let's introduce an initializer that can be invoked in the propertry wrapper:

```diff
 struct ContentView: View {
-  @SharedReader var config: Config
+  @SharedReader(value: Config()) var config

-  init() {
-    _config = .constant(Config())
-  }
-
   var body: some View {
     VStack {
       // ...
     }
     .task {
       try await $posts.load(.remoteConfig)
     }
   }
 }
```