### PR TITLE
Allow result to be discardable

### DIFF
--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -135,6 +135,7 @@ public struct Shared<Value> {
   ///   - line: The source `#line` associated with the lock.
   ///   - column: The source `#column` associated with the lock.
   /// - Returns: The value returned from `operation`.
+  @discardableResult
   public func withLock<R>(
     _ operation: (inout Value) throws -> R,
     fileID: StaticString = #fileID,


### PR DESCRIPTION
Hi! Not sure if this was on your radar or had already been discussed, if so feel free to decline and close. Just would be nice to have to get rid of warnings.

 Quick example:
```swift
private class Test {
  @Shared(.inMemory("countArray")) var countArray: [Int] = [0]

  func test() {
    $countArray.withLock { $0.removeLast() } // warning of unused result
  }
}
```
<img width="1164" alt="Screenshot 2025-02-05 at 8 08 27 PM" src="https://github.com/user-attachments/assets/a8f7260f-4bba-40a6-91f3-6ad9cda045c5" />

