### PR TITLE
Add `@SwiftUI.State.Shared` and `@SwiftUI.State.SharedReader`

### DIFF
--- a/Examples/APIClientDemo/ContentView.swift
+++ b/Examples/APIClientDemo/ContentView.swift
@@ -11,7 +11,7 @@ private let readMe = """
 
 struct ContentView: View {
   @Shared(.appStorage("count")) var count = 0
-  @SharedReader(.fact(nil)) var fact
+  @State.SharedReader(.fact(nil)) var fact
   @State var isAboutPresented = false
 
   var body: some View {

--- a/Sources/Sharing/Documentation.docc/Articles/DynamicKeys.md
+++ b/Sources/Sharing/Documentation.docc/Articles/DynamicKeys.md
@@ -47,7 +47,7 @@ If you dynamically change the key of the property wrapper in the view, for examp
 
 ```swift
 $value.load(.newKey)
-// or…
+// or...
 $value = Shared(.newKey)
 ```
 

--- a/Sources/Sharing/Documentation.docc/Articles/DynamicKeys.md
+++ b/Sources/Sharing/Documentation.docc/Articles/DynamicKeys.md
@@ -1,0 +1,61 @@
+# Dynamic Keys
+
+Learn how to dynamically change the key that powers your shared state.
+
+## Overview
+
+Sharing uses the ``SharedKey`` protocol to express the functionality of loading, saving and 
+subscribing to changes of an external storage system, such as user defaults, the file system
+and more. Often one needs to dynamically update the key so that the shared state can load 
+different data. A common example of this is using `@SharedReader` to load data from a SQLite
+database, and needing to update the query with info specified by the user, such as a search string.
+
+Learn about the techniques to do this below.
+
+### Loading a new key
+
+There are two ways to load a new key into `@Shared` and `@SharedReader`. If the change is due to
+the user changing something, such as a search string, you can use ``Shared/load(_:)``:
+
+```swift
+.task(id: searchText) {
+  do {
+    try await $items.load(.search(searchText))
+  } catch {
+    // Handle error
+  }
+}
+```
+
+If the change is not due to user action, such as the first appearance of the view, then you can
+re-assign the projected value of the shared state directly:
+
+```swift
+init() {
+  $items = SharedReader(.search(searchText))
+}
+```
+
+### SwiftUI views
+
+There is one nuance to be aware of when using [`@Shared`](<doc:Shared>) and 
+ [`@SharedReader`](<doc:SharedReader>) directly in a SwiftUI view. When the view is recreated 
+(which can happen many times and is an intentional design of SwiftUI), the corresponding 
+`@Shared` and `@SharedReader` wrappers can also be created.
+
+If you dynamically change the key of the property wrapper in the view, for example like this:
+
+```swift
+$value.load(.newKey)
+// or…
+$value = Shared(.newKey)
+```
+
+…then this key may be reset when the view is recreated. In order to prevent this you can use the
+version of `Shared` and `SharedReader` that works like `@State` in views:
+
+```swift
+@State.Shared(.key) var value
+```
+
+See ``SwiftUICore/State/Shared`` and ``SwiftUICore/State/SharedReader`` for more info.

--- a/Sources/Sharing/Documentation.docc/Articles/Gotchas.md
+++ b/Sources/Sharing/Documentation.docc/Articles/Gotchas.md
@@ -65,3 +65,28 @@ extension TodosFeature: Codable {
   }
 }
 ```
+
+#### SwiftUI Views
+
+There is one nuance to be aware of when using [`@Shared`](<doc:Shared>) and 
+[`@SharedReader`](<doc:SharedReader>) directly in a SwiftUI view. When the view is recreated 
+(which can happen many times and is an intentional design of SwiftUI), the corresponding 
+`@Shared` and `@SharedReader` wrappers can also be created.
+
+If you dynamically change the key of the property wrapper in the view, for example like this:
+
+```swift
+$value.load(.newKey)
+// or…
+$value = Shared(.newKey)
+```
+
+…then this key may be reset when the view is recreated. In order to prevent this you can use the
+version of `Shared` and `SharedReader` that works like `@State` in views:
+
+```swift
+@State.Shared(.key) var value
+```
+
+See ``SwiftUICore/State/Shared`` and ``SwiftUICore/State/SharedReader`` for more info, as well
+as the article <doc:DynamicKeys>.

--- a/Sources/Sharing/Documentation.docc/Articles/ObservingChanges.md
+++ b/Sources/Sharing/Documentation.docc/Articles/ObservingChanges.md
@@ -46,6 +46,29 @@ struct CounterView: View {
 In each of these cases the view will automatically re-compute its body when the shared state 
 changes.
 
+> Important: 
+> There is one nuance to be aware of when using [`@Shared`](<doc:Shared>) and 
+> [`@SharedReader`](<doc:SharedReader>) directly in a SwiftUI view. When the view is recreated 
+> (which can happen many times and is an intentional design of SwiftUI), the corresponding 
+> `@Shared` and `@SharedReader` wrappers can also be created.
+> 
+> If you dynamically change the key of the property wrapper in the view, for example like this:
+> 
+> ```swift
+> $value.load(.newKey)
+> // or…
+> $value = Shared(.newKey)
+> ```
+> 
+> …then this key may be reset when the view is recreated. In order to prevent this you can use the
+> version of `Shared` and `SharedReader` that works like `@State` in views:
+> 
+> ```swift
+> @State.Shared(.key) var value
+> ```
+> 
+> See ``SwiftUICore/State/Shared`` and ``SwiftUICore/State/SharedReader`` for more info.
+
 ## Publisher of values
 
 It is possible to get a Combine publisher of changes in a piece of shared state. Every `Shared` 

--- a/Sources/Sharing/Documentation.docc/Sharing.md
+++ b/Sources/Sharing/Documentation.docc/Sharing.md
@@ -165,6 +165,7 @@ complex problems with `@Shared`. Check out [this][examples-dir] directory to see
 - <doc:PersistenceStrategies>
 - <doc:MutatingSharedState>
 - <doc:ObservingChanges>
+- <doc:DynamicKeys>
 - <doc:DerivingSharedState>
 - <doc:TypeSafeKeys>
 - <doc:InitializationRules>

--- a/Sources/Sharing/SwiftUIStateSharing.swift
+++ b/Sources/Sharing/SwiftUIStateSharing.swift
@@ -2,27 +2,66 @@
   import SwiftUI
 
   extension State {
+    /// A dynamic property that holds a shared reader in view state.
+    ///
+    /// This property is a more ergonomic shorthand for holding a ``Shared`` in SwiftUI's `@State`
+    /// property wrapper, and can be initialized in all the same ways `@Shared` can be initialized.
+    ///
+    /// For example, if you simply use both property wrappers in a view, initializing and accessing
+    /// the projected shared value is more cumbersome:
+    ///
+    /// ```diff
+    ///  struct BooksView: View {
+    /// -  @State @Shared var books: [Book]
+    /// +  @State.Shared var books: [Book]
+    ///
+    ///    init(
+    /// -    _books = State(wrappedValue: Shared(.books(searchText)))
+    /// +    _books = State.Shared(.books(searchText))
+    ///    )
+    ///
+    ///    var body: some View {
+    ///      List {
+    ///        // ...
+    ///      }
+    ///      .refreshable {
+    /// -      try? await $books.wrappedValue.load(.books(searchText))
+    /// +      try? await $books.load(.books(searchText))
+    ///      }
+    ///      .searchable(text: $searchText)
+    ///      .onChange(of: searchText) {
+    /// -      $books.wrappedValue = Shared(.books(searchText))
+    /// +      $books = Shared(.books(searchText))
+    ///      }
+    ///    }
+    ///  }
+    /// ```
     @propertyWrapper
     public struct Shared: DynamicProperty, Sendable {
       @SwiftUI.State private var shared: Sharing.Shared<Value>
 
+      @_documentation(visibility: private)
       public var wrappedValue: Value {
         shared.wrappedValue
       }
 
+      @_documentation(visibility: private)
       public var projectedValue: Sharing.Shared<Value> {
         get { shared }
         nonmutating set { shared.projectedValue = newValue }
       }
 
+      @_documentation(visibility: private)
       public init(value: sending Value) {
         shared = Sharing.Shared(value: value)
       }
 
+      @_documentation(visibility: private)
       public init(projectedValue: Sharing.Shared<Value>) {
         shared = projectedValue
       }
 
+      @_documentation(visibility: private)
       public init(
         wrappedValue: @autoclosure () -> Value,
         _ key: some SharedKey<Value>
@@ -31,15 +70,18 @@
       }
 
       @_disfavoredOverload
+      @_documentation(visibility: private)
       public init<Wrapped>(_ key: some SharedKey<Value>) where Value == Wrapped? {
         shared = Sharing.Shared(key)
       }
 
+      @_documentation(visibility: private)
       public init(_ key: (some SharedKey<Value>).Default) {
         shared = Sharing.Shared(wrappedValue: key.initialValue, key)
       }
 
       @_disfavoredOverload
+      @_documentation(visibility: private)
       public init(
         wrappedValue: @autoclosure () -> Value,
         _ key: (some SharedKey<Value>).Default
@@ -47,37 +89,79 @@
         shared = Sharing.Shared(wrappedValue: wrappedValue(), key)
       }
 
+      @_documentation(visibility: private)
       public init(require key: some SharedKey<Value>) async throws {
         shared = try await Sharing.Shared(require: key)
       }
 
+      @_documentation(visibility: private)
       @available(*, unavailable, message: "Assign a default value")
       public init(_ key: some SharedKey<Value>) {
         fatalError()
       }
     }
 
+    /// A dynamic property that holds a shared reader in view state.
+    ///
+    /// This property is a more ergonomic shorthand for holding a ``SharedReader`` in SwiftUI's
+    /// `@State` property wrapper, and can be initialized in all the same ways `@SharedReader` can
+    /// be initialized.
+    ///
+    /// For example, if you simply use both property wrappers in a view, initializing and accessing
+    /// the projected shared value is more cumbersome:
+    ///
+    /// ```diff
+    ///  struct BooksView: View {
+    /// -  @State @SharedReader var books: [Book]
+    /// +  @State.SharedReader var books: [Book]
+    ///
+    ///    init(
+    /// -    _books = State(wrappedValue: SharedReader(.books(searchText)))
+    /// +    _books = State.SharedReader(.books(searchText))
+    ///    )
+    ///
+    ///    var body: some View {
+    ///      List {
+    ///        // ...
+    ///      }
+    ///      .refreshable {
+    /// -      try? await $books.wrappedValue.load(.books(searchText))
+    /// +      try? await $books.load(.books(searchText))
+    ///      }
+    ///      .searchable(text: $searchText)
+    ///      .onChange(of: searchText) {
+    /// -      $books.wrappedValue = SharedReader(.books(searchText))
+    /// +      $books = SharedReader(.books(searchText))
+    ///      }
+    ///    }
+    ///  }
+    /// ```
     @propertyWrapper
     public struct SharedReader: DynamicProperty, Sendable {
       @SwiftUI.State private var shared: Sharing.SharedReader<Value>
 
+      @_documentation(visibility: private)
       public var wrappedValue: Value {
         shared.wrappedValue
       }
 
+      @_documentation(visibility: private)
       public var projectedValue: Sharing.SharedReader<Value> {
         get { shared }
         nonmutating set { shared.projectedValue = newValue }
       }
 
+      @_documentation(visibility: private)
       public init(value: sending Value) {
         shared = Sharing.SharedReader(value: value)
       }
 
+      @_documentation(visibility: private)
       public init(projectedValue: Sharing.SharedReader<Value>) {
         shared = projectedValue
       }
 
+      @_documentation(visibility: private)
       public init(
         wrappedValue: @autoclosure () -> Value,
         _ key: some SharedReaderKey<Value>
@@ -105,6 +189,7 @@
         shared = Sharing.SharedReader(key)
       }
 
+      @_documentation(visibility: private)
       public init(_ key: (some SharedReaderKey<Value>).Default) {
         shared = Sharing.SharedReader(key)
       }
@@ -132,6 +217,7 @@
         shared = Sharing.SharedReader(wrappedValue: wrappedValue(), key)
       }
 
+      @_documentation(visibility: private)
       public init(require key: some SharedReaderKey<Value>) async throws {
         shared = try await Sharing.SharedReader(require: key)
       }
@@ -142,6 +228,7 @@
         shared = try await Sharing.SharedReader(require: key)
       }
 
+      @_documentation(visibility: private)
       @available(*, unavailable, message: "Assign a default value")
       public init(_ key: some SharedReaderKey<Value>) {
         fatalError()

--- a/Sources/Sharing/SwiftUIStateSharing.swift
+++ b/Sources/Sharing/SwiftUIStateSharing.swift
@@ -1,0 +1,182 @@
+#if canImport(SwiftUI)
+  import SwiftUI
+
+  extension State {
+    @propertyWrapper
+    public struct Shared: DynamicProperty, Sendable {
+      @SwiftUI.State private var shared: Sharing.Shared<Value>
+
+      public var wrappedValue: Value {
+        shared.wrappedValue
+      }
+
+      public var projectedValue: Sharing.Shared<Value> {
+        get { shared }
+        nonmutating set { shared.projectedValue = newValue }
+      }
+
+      public init(value: sending Value) {
+        shared = Sharing.Shared(value: value)
+      }
+
+      public init(projectedValue: Sharing.Shared<Value>) {
+        shared = projectedValue
+      }
+
+      public init(
+        wrappedValue: @autoclosure () -> Value,
+        _ key: some SharedKey<Value>
+      ) {
+        shared = Sharing.Shared(wrappedValue: wrappedValue(), key)
+      }
+
+      @_disfavoredOverload
+      public init<Wrapped>(_ key: some SharedKey<Value>) where Value == Wrapped? {
+        shared = Sharing.Shared(key)
+      }
+
+      public init(_ key: (some SharedKey<Value>).Default) {
+        shared = Sharing.Shared(wrappedValue: key.initialValue, key)
+      }
+
+      @_disfavoredOverload
+      public init(
+        wrappedValue: @autoclosure () -> Value,
+        _ key: (some SharedKey<Value>).Default
+      ) {
+        shared = Sharing.Shared(wrappedValue: wrappedValue(), key)
+      }
+
+      public init(require key: some SharedKey<Value>) async throws {
+        shared = try await Sharing.Shared(require: key)
+      }
+
+      @available(*, unavailable, message: "Assign a default value")
+      public init(_ key: some SharedKey<Value>) {
+        fatalError()
+      }
+    }
+
+    @propertyWrapper
+    public struct SharedReader: DynamicProperty, Sendable {
+      @SwiftUI.State private var shared: Sharing.SharedReader<Value>
+
+      public var wrappedValue: Value {
+        shared.wrappedValue
+      }
+
+      public var projectedValue: Sharing.SharedReader<Value> {
+        get { shared }
+        nonmutating set { shared.projectedValue = newValue }
+      }
+
+      public init(value: sending Value) {
+        shared = Sharing.SharedReader(value: value)
+      }
+
+      public init(projectedValue: Sharing.SharedReader<Value>) {
+        shared = projectedValue
+      }
+
+      public init(
+        wrappedValue: @autoclosure () -> Value,
+        _ key: some SharedReaderKey<Value>
+      ) {
+        shared = Sharing.SharedReader(wrappedValue: wrappedValue(), key)
+      }
+
+      @_disfavoredOverload
+      @_documentation(visibility: private)
+      public init(
+        wrappedValue: @autoclosure () -> Value,
+        _ key: some SharedKey<Value>
+      ) {
+        shared = Sharing.SharedReader(wrappedValue: wrappedValue(), key)
+      }
+
+      @_disfavoredOverload
+      public init<Wrapped>(_ key: some SharedReaderKey<Value>) where Value == Wrapped? {
+        shared = Sharing.SharedReader(key)
+      }
+
+      @_disfavoredOverload
+      @_documentation(visibility: private)
+      public init<Wrapped>(_ key: some SharedKey<Value>) where Value == Wrapped? {
+        shared = Sharing.SharedReader(key)
+      }
+
+      public init(_ key: (some SharedReaderKey<Value>).Default) {
+        shared = Sharing.SharedReader(key)
+      }
+
+      @_disfavoredOverload
+      @_documentation(visibility: private)
+      public init(_ key: (some SharedKey<Value>).Default) {
+        shared = Sharing.SharedReader(key)
+      }
+
+      @_disfavoredOverload
+      public init(
+        wrappedValue: @autoclosure () -> Value,
+        _ key: (some SharedReaderKey<Value>).Default
+      ) {
+        shared = Sharing.SharedReader(wrappedValue: wrappedValue(), key)
+      }
+
+      @_disfavoredOverload
+      @_documentation(visibility: private)
+      public init(
+        wrappedValue: @autoclosure () -> Value,
+        _ key: (some SharedKey<Value>).Default
+      ) {
+        shared = Sharing.SharedReader(wrappedValue: wrappedValue(), key)
+      }
+
+      public init(require key: some SharedReaderKey<Value>) async throws {
+        shared = try await Sharing.SharedReader(require: key)
+      }
+
+      @_disfavoredOverload
+      @_documentation(visibility: private)
+      public init(require key: some SharedKey<Value>) async throws {
+        shared = try await Sharing.SharedReader(require: key)
+      }
+
+      @available(*, unavailable, message: "Assign a default value")
+      public init(_ key: some SharedReaderKey<Value>) {
+        fatalError()
+      }
+
+      @_disfavoredOverload
+      @_documentation(visibility: private)
+      @available(*, unavailable, message: "Assign a default value")
+      public init(_ key: some SharedKey<Value>) {
+        fatalError()
+      }
+    }
+  }
+
+  extension State.Shared: Equatable where Value: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.shared == rhs.shared
+    }
+  }
+
+  extension State.Shared: Identifiable where Value: Identifiable {
+    public var id: Value.ID {
+      shared.id
+    }
+  }
+
+  extension State.SharedReader: Equatable where Value: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.shared == rhs.shared
+    }
+  }
+
+  extension State.SharedReader: Identifiable where Value: Identifiable {
+    public var id: Value.ID {
+      shared.id
+    }
+  }
+#endif

--- a/Sources/Sharing/SwiftUIStateSharing.swift
+++ b/Sources/Sharing/SwiftUIStateSharing.swift
@@ -2,7 +2,7 @@
   import SwiftUI
 
   extension State {
-    /// A dynamic property that holds a shared reader in view state.
+    /// A dynamic property that holds a shared property in view state.
     ///
     /// This property is a more ergonomic shorthand for holding a ``Shared`` in SwiftUI's `@State`
     /// property wrapper, and can be initialized in all the same ways `@Shared` can be initialized.

--- a/Sources/Sharing/SwiftUIStateSharing.swift
+++ b/Sources/Sharing/SwiftUIStateSharing.swift
@@ -7,8 +7,8 @@
     /// This property is a more ergonomic shorthand for holding a ``Shared`` in SwiftUI's `@State`
     /// property wrapper, and can be initialized in all the same ways `@Shared` can be initialized.
     ///
-    /// For example, if you simply use both property wrappers in a view, initializing and accessing
-    /// the projected shared value is more cumbersome:
+    /// Instead of explicitly going through extra layers of `$state.wrappedValue` to get to the
+    /// shared property wrapper, you can project directly to it:
     ///
     /// ```diff
     ///  struct BooksView: View {
@@ -107,8 +107,8 @@
     /// `@State` property wrapper, and can be initialized in all the same ways `@SharedReader` can
     /// be initialized.
     ///
-    /// For example, if you simply use both property wrappers in a view, initializing and accessing
-    /// the projected shared value is more cumbersome:
+    /// Instead of explicitly going through extra layers of `$state.wrappedValue` to get to the
+    /// shared property wrapper, you can project directly to it:
     ///
     /// ```diff
     ///  struct BooksView: View {

--- a/Sources/Sharing/SwiftUIStateSharing.swift
+++ b/Sources/Sharing/SwiftUIStateSharing.swift
@@ -51,10 +51,17 @@
         nonmutating set { shared.projectedValue = newValue }
       }
 
-      @_documentation(visibility: private)
-      public init(value: sending Value) {
-        shared = Sharing.Shared(value: value)
-      }
+      #if compiler(>=6)
+        @_documentation(visibility: private)
+        public init(value: sending Value) {
+          shared = Sharing.Shared(value: value)
+        }
+      #else
+        @_documentation(visibility: private)
+        public init(value: Value) {
+          shared = Sharing.Shared(value: value)
+        }
+      #endif
 
       @_documentation(visibility: private)
       public init(projectedValue: Sharing.Shared<Value>) {
@@ -151,10 +158,17 @@
         nonmutating set { shared.projectedValue = newValue }
       }
 
-      @_documentation(visibility: private)
-      public init(value: sending Value) {
-        shared = Sharing.SharedReader(value: value)
-      }
+      #if compiler(>=6)
+        @_documentation(visibility: private)
+        public init(value: sending Value) {
+          shared = Sharing.SharedReader(value: value)
+        }
+      #else
+        @_documentation(visibility: private)
+        public init(value: Value) {
+          shared = Sharing.SharedReader(value: value)
+        }
+      #endif
 
       @_documentation(visibility: private)
       public init(projectedValue: Sharing.SharedReader<Value>) {

--- a/Sources/Sharing/SwiftUIStateSharing.swift
+++ b/Sources/Sharing/SwiftUIStateSharing.swift
@@ -37,7 +37,7 @@
     ///  }
     /// ```
     @propertyWrapper
-    public struct Shared: DynamicProperty, Sendable {
+    public struct Shared: DynamicProperty {
       @SwiftUI.State private var shared: Sharing.Shared<Value>
 
       @_documentation(visibility: private)
@@ -137,7 +137,7 @@
     ///  }
     /// ```
     @propertyWrapper
-    public struct SharedReader: DynamicProperty, Sendable {
+    public struct SharedReader: DynamicProperty {
       @SwiftUI.State private var shared: Sharing.SharedReader<Value>
 
       @_documentation(visibility: private)
@@ -266,4 +266,10 @@
       shared.id
     }
   }
+
+  #if compiler(>=6)
+    extension State.Shared: Sendable where Value: Sendable {}
+
+    extension State.SharedReader: Sendable where Value: Sendable {}
+  #endif
 #endif


### PR DESCRIPTION
While `@Shared` and `@SharedReader` work perfectly fine in the view most of the time, swapping out their backing keys can cause the view hierarchy to lose these changes when recomputed/reinitialized, and so it is appropriate to use `@State` to allow views to hold onto these changes locally.

Unfortunately, composing property wrappers isn't super ergonomic, especially when one needs to access a nested, projected value, so instead let's add a property wrapper that smushes `@State` and `@Shared` together in a package that for the most part works like `@Shared`.