### PR TITLE
Don't send value to subject when asserted.

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -47,7 +47,10 @@ final class _BoxReference<Value>: MutableReference, Observable, Perceptible, @un
   #if canImport(Combine)
     private var value: Value {
       willSet {
-        subject.send(newValue)
+        @Dependency(\.snapshots) var snapshots
+        if !snapshots.isAsserting {
+          subject.send(newValue)
+        }
       }
     }
     let subject = PassthroughRelay<Value>()
@@ -173,7 +176,10 @@ final class _PersistentReference<Key: SharedReaderKey>:
   #if canImport(Combine)
     private var value: Key.Value {
       willSet {
-        subject.send(newValue)
+        @Dependency(\.snapshots) var snapshots
+        if !snapshots.isAsserting {
+          subject.send(newValue)
+        }
       }
     }
     private let subject = PassthroughRelay<Value>()

--- a/Tests/SharingTests/SharedChangeTrackerTests.swift
+++ b/Tests/SharingTests/SharedChangeTrackerTests.swift
@@ -78,6 +78,30 @@ import Testing
     }
   }
 
+  @Test func assertedChanges() {
+    @Shared(value: 0) var count
+
+    let counts = Mutex<[Int]>([])
+    let cancellable = $count.publisher.sink { @Sendable value in
+      counts.withLock { $0.append(value) }
+    }
+    defer { _ = cancellable }
+
+    let tracker = SharedChangeTracker()
+    tracker.track {
+      $count.withLock { $0 += 1 }
+    }
+
+    tracker.assert {
+      #expect($count != $count)
+
+      $count.withLock { $0 = 1 }
+
+      #expect($count == $count)
+      #expect(counts.withLock(\.self) == [0 ,1])
+    }
+  }
+
   @Test func unassertedChanges() {
     @Shared(value: 0) var count
 


### PR DESCRIPTION
This fixes https://github.com/pointfreeco/swift-composable-architecture/issues/3605