### PR TITLE
Use `DefaultKey.Base` as lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
         run: |
           PREFIX=/opt/swift
           set -ex
-          curl -f -o /tmp/swift.tar.gz "https://download.swift.org/swift-6.0.2-release/ubuntu2204/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE-ubuntu22.04.tar.gz"
+          curl -f -o /tmp/swift.tar.gz "https://download.swift.org/swift-6.0.3-release/ubuntu2204/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE-ubuntu22.04.tar.gz"
           sudo mkdir -p $PREFIX; sudo tar -xzf /tmp/swift.tar.gz -C $PREFIX --strip-component 1
-          $PREFIX/usr/bin/swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0.2-RELEASE/swift-wasm-6.0.2-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 6ffedb055cb9956395d9f435d03d53ebe9f6a8d45106b979d1b7f53358e1dcb4
+          $PREFIX/usr/bin/swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0.3-RELEASE/swift-wasm-6.0.3-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 31d3585b06dd92de390bacc18527801480163188cd7473f492956b5e213a8618
           echo "$PREFIX/usr/bin" >> $GITHUB_PATH
 
       - name: Build

--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -66,7 +66,7 @@ extension Shared {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
   public init(_ key: (some SharedKey<Value>).Default) {
-    self.init(wrappedValue: key.initialValue, key)
+    self.init(wrappedValue: key.initialValue, key.base)
   }
 
   /// Creates a shared reference to a value using a shared key by overriding its default value.
@@ -76,12 +76,11 @@ extension Shared {
   ///     shared key.
   ///   - key: A shared key associated with the shared reference. It is responsible for loading
   ///     and saving the shared reference's value from some external source.
-  @_disfavoredOverload
   public init(
     wrappedValue: @autoclosure () -> Value,
     _ key: (some SharedKey<Value>).Default
   ) {
-    self.init(wrappedValue: wrappedValue(), key)
+    self.init(wrappedValue: wrappedValue(), key.base)
   }
 
   /// Replaces a shared reference's key and attempts to load its value.

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -117,7 +117,7 @@ extension SharedReader {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
   public init(_ key: (some SharedReaderKey<Value>).Default) {
-    self.init(wrappedValue: key.initialValue, key)
+    self.init(wrappedValue: key.initialValue, key.base)
   }
 
   @_disfavoredOverload
@@ -134,21 +134,19 @@ extension SharedReader {
   ///     shared key.
   ///   - key: A shared key associated with the shared reference. It is responsible for loading the
   ///     shared reference's value from some external source.
-  @_disfavoredOverload
   public init(
     wrappedValue: @autoclosure () -> Value,
     _ key: (some SharedReaderKey<Value>).Default
   ) {
-    self.init(wrappedValue: wrappedValue(), key)
+    self.init(wrappedValue: wrappedValue(), key.base)
   }
 
-  @_disfavoredOverload
   @_documentation(visibility: private)
   public init(
     wrappedValue: @autoclosure () -> Value,
     _ key: (some SharedKey<Value>).Default
   ) {
-    self.init(wrappedValue: wrappedValue(), key)
+    self.init(wrappedValue: wrappedValue(), key.base)
   }
 
   /// Replaces a shared reference's key and attempts to load its value.

--- a/Tests/SharingTests/DefaultTests.swift
+++ b/Tests/SharingTests/DefaultTests.swift
@@ -88,10 +88,84 @@ import Testing
   @Test func initialValue() {
     #expect(InMemoryKey<Bool>.Default.isOn.initialValue == false)
   }
+
+  @Suite struct DefaultNotDefaultInterplay {
+    @Test func writerDefault_readerDefault() {
+      @Shared(.count1) var count
+      @SharedReader(.count2) var countReader
+
+      $count.withLock { $0 += 1 }
+
+      #expect(count == 2)
+      #expect(countReader == 2)
+    }
+
+    @Test func readerDefault_writerDefault() {
+      @SharedReader(.count2) var countReader
+      @Shared(.count1) var count
+
+      $count.withLock { $0 += 1 }
+
+      #expect(count == 3)
+      #expect(countReader == 3)
+    }
+
+    @Test func writer_readerDefault() {
+      @Shared(.count1) var count = 3
+      @SharedReader(.count2) var countReader
+
+      $count.withLock { $0 += 1 }
+
+      #expect(count == 4)
+      #expect(countReader == 4)
+    }
+
+    @Test func writerDefault_reader() {
+      @Shared(.count1) var count
+      @SharedReader(.count2) var countReader = 3
+
+      $count.withLock { $0 += 1 }
+
+      #expect(count == 2)
+      #expect(countReader == 2)
+    }
+
+    @Test func reader_writerDefault() {
+      @SharedReader(.count2) var countReader = 3
+      @Shared(.count1) var count
+
+      $count.withLock { $0 += 1 }
+
+      #expect(count == 4)
+      #expect(countReader == 4)
+    }
+
+    @Test func readerDefault_writer() {
+      @SharedReader(.count2) var countReader
+      @Shared(.count1) var count = 3
+
+      $count.withLock { $0 += 1 }
+
+      #expect(count == 3)
+      #expect(countReader == 3)
+    }
+  }
 }
 
 extension SharedReaderKey where Self == InMemoryKey<Bool>.Default {
   fileprivate static var isOn: Self {
     Self[.inMemory("isOn"), default: false]
+  }
+}
+
+extension SharedKey where Self == InMemoryKey<Int>.Default {
+  fileprivate static var count1: Self {
+    Self[.inMemory("count"), default: 1]
+  }
+}
+
+extension SharedReaderKey where Self == InMemoryKey<Int>.Default {
+  fileprivate static var count2: Self {
+    Self[.inMemory("count"), default: 2]
   }
 }

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -185,13 +185,13 @@ import Testing
 
         #expect(
           $count.description == """
-            Shared<Int>(AppStorageKey<Int>.Default[.appStorage("count"), default: 0])
+            Shared<Int>(.appStorage("count"))
             """
         )
 
         #expect(
           SharedReader($count).description == """
-            SharedReader<Int>(AppStorageKey<Int>.Default[.appStorage("count"), default: 0])
+            SharedReader<Int>(.appStorage("count"))
             """
         )
       }
@@ -200,13 +200,13 @@ import Testing
 
         #expect(
           $count.description == """
-            Shared<Int>(AppStorageKey<Int>.Default[.appStorage("count"), default: 0])
+            Shared<Int>(.appStorage("count"))
             """
         )
 
         #expect(
           SharedReader($count).description == """
-            SharedReader<Int>(AppStorageKey<Int>.Default[.appStorage("count"), default: 0])
+            SharedReader<Int>(.appStorage("count"))
             """
         )
       }


### PR DESCRIPTION
Otherwise it is possible for 2 keys to point to the same underlying storage but get out of sync.

Fixes #121.