### PR TITLE
Make file writes atomic, and don't decode empty file.

### DIFF
--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -379,8 +379,8 @@
           close(source.handle)
         }
       },
-      load: { url in try
-        Data(contentsOf: url)
+      load: { url in
+        try Data(contentsOf: url)
       },
       save: { data, url in
         try data.write(to: url, options: .atomic)

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -147,7 +147,7 @@
                 guard state.workItem == nil
                 else { return }
 
-                if storage.fileExists(url) {
+                if self.storage.fileExists(url) {
                   subscriber.yield(with: Result { try self.decode(self.storage.load(self.url)) })
                 } else {
                   subscriber.yieldReturningInitialValue()

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -147,7 +147,7 @@
                 guard state.workItem == nil
                 else { return }
 
-                if self.storage.fileExists(url) {
+                if self.storage.fileExists(self.url) {
                   subscriber.yield(with: Result { try self.decode(self.storage.load(self.url)) })
                 } else {
                   subscriber.yieldReturningInitialValue()

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -327,39 +327,36 @@
     ///
     /// This is the version of the ``Dependencies/DependencyValues/defaultFileStorage`` dependency
     /// that is used by default when running your app in the simulator or on device.
-    public static var fileSystem: Self {
-      let lock = NSLock()
-      return Self(
-        id: AnyHashableSendable(DispatchQueue.main),
-        async: { DispatchQueue.main.async(execute: $0) },
-        asyncAfter: { DispatchQueue.main.asyncAfter(deadline: .now() + $0, execute: $1) },
-        attributesOfItemAtPath: { try FileManager.default.attributesOfItem(atPath: $0) },
-        createDirectory: {
-          try FileManager.default.createDirectory(at: $0, withIntermediateDirectories: $1)
-        },
-        fileExists: { FileManager.default.fileExists(atPath: $0.path) },
-        fileSystemSource: {
-          let fileDescriptor = open($0.path, O_EVTONLY)
-          guard fileDescriptor != -1 else {
-            struct FileDescriptorError: Error {}
-            throw FileDescriptorError()
-          }
-          let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: fileDescriptor,
-            eventMask: $1,
-            queue: DispatchQueue.main
-          )
-          source.setEventHandler(handler: $2)
-          source.resume()
-          return SharedSubscription {
-            source.cancel()
-            close(source.handle)
-          }
-        },
-        load: { url in try Data(contentsOf: url) },
-        save: { data, url in try data.write(to: url) }
-      )
-    }
+    public static let fileSystem = Self(
+      id: AnyHashableSendable(DispatchQueue.main),
+      async: { DispatchQueue.main.async(execute: $0) },
+      asyncAfter: { DispatchQueue.main.asyncAfter(deadline: .now() + $0, execute: $1) },
+      attributesOfItemAtPath: { try FileManager.default.attributesOfItem(atPath: $0) },
+      createDirectory: {
+        try FileManager.default.createDirectory(at: $0, withIntermediateDirectories: $1)
+      },
+      fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+      fileSystemSource: {
+        let fileDescriptor = open($0.path, O_EVTONLY)
+        guard fileDescriptor != -1 else {
+          struct FileDescriptorError: Error {}
+          throw FileDescriptorError()
+        }
+        let source = DispatchSource.makeFileSystemObjectSource(
+          fileDescriptor: fileDescriptor,
+          eventMask: $1,
+          queue: DispatchQueue.main
+        )
+        source.setEventHandler(handler: $2)
+        source.resume()
+        return SharedSubscription {
+          source.cancel()
+          close(source.handle)
+        }
+      },
+      load: { url in try Data(contentsOf: url) },
+      save: { data, url in try data.write(to: url) }
+    )
 
     /// File storage that emulates a file system without actually writing anything to disk.
     ///

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -379,8 +379,12 @@
           close(source.handle)
         }
       },
-      load: { url in try Data(contentsOf: url) },
-      save: { data, url in try data.write(to: url, options: .atomic) }
+      load: { url in try
+        Data(contentsOf: url)
+      },
+      save: { data, url in
+        try data.write(to: url, options: .atomic)
+      }
     )
 
     /// File storage that emulates a file system without actually writing anything to disk.

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -107,7 +107,8 @@
     public func load(context _: LoadContext<Value>, continuation: LoadContinuation<Value>) {
       guard
         let data = try? storage.load(url),
-        data != stubBytes
+        data != stubBytes,
+        !data.isEmpty
       else {
         continuation.resumeReturningInitialValue()
         return
@@ -326,36 +327,39 @@
     ///
     /// This is the version of the ``Dependencies/DependencyValues/defaultFileStorage`` dependency
     /// that is used by default when running your app in the simulator or on device.
-    public static let fileSystem = Self(
-      id: AnyHashableSendable(DispatchQueue.main),
-      async: { DispatchQueue.main.async(execute: $0) },
-      asyncAfter: { DispatchQueue.main.asyncAfter(deadline: .now() + $0, execute: $1) },
-      attributesOfItemAtPath: { try FileManager.default.attributesOfItem(atPath: $0) },
-      createDirectory: {
-        try FileManager.default.createDirectory(at: $0, withIntermediateDirectories: $1)
-      },
-      fileExists: { FileManager.default.fileExists(atPath: $0.path) },
-      fileSystemSource: {
-        let fileDescriptor = open($0.path, O_EVTONLY)
-        guard fileDescriptor != -1 else {
-          struct FileDescriptorError: Error {}
-          throw FileDescriptorError()
-        }
-        let source = DispatchSource.makeFileSystemObjectSource(
-          fileDescriptor: fileDescriptor,
-          eventMask: $1,
-          queue: DispatchQueue.main
-        )
-        source.setEventHandler(handler: $2)
-        source.resume()
-        return SharedSubscription {
-          source.cancel()
-          close(source.handle)
-        }
-      },
-      load: { try Data(contentsOf: $0) },
-      save: { try $0.write(to: $1) }
-    )
+    public static var fileSystem: Self {
+      let lock = NSLock()
+      return Self(
+        id: AnyHashableSendable(DispatchQueue.main),
+        async: { DispatchQueue.main.async(execute: $0) },
+        asyncAfter: { DispatchQueue.main.asyncAfter(deadline: .now() + $0, execute: $1) },
+        attributesOfItemAtPath: { try FileManager.default.attributesOfItem(atPath: $0) },
+        createDirectory: {
+          try FileManager.default.createDirectory(at: $0, withIntermediateDirectories: $1)
+        },
+        fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+        fileSystemSource: {
+          let fileDescriptor = open($0.path, O_EVTONLY)
+          guard fileDescriptor != -1 else {
+            struct FileDescriptorError: Error {}
+            throw FileDescriptorError()
+          }
+          let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fileDescriptor,
+            eventMask: $1,
+            queue: DispatchQueue.main
+          )
+          source.setEventHandler(handler: $2)
+          source.resume()
+          return SharedSubscription {
+            source.cancel()
+            close(source.handle)
+          }
+        },
+        load: { url in try Data(contentsOf: url) },
+        save: { data, url in try data.write(to: url) }
+      )
+    }
 
     /// File storage that emulates a file system without actually writing anything to disk.
     ///

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -359,7 +359,7 @@
         }
       },
       load: { url in try Data(contentsOf: url) },
-      save: { data, url in try data.write(to: url) }
+      save: { data, url in try data.write(to: url, options: .atomic) }
     )
 
     /// File storage that emulates a file system without actually writing anything to disk.

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -107,7 +107,6 @@
     public func load(context _: LoadContext<Value>, continuation: LoadContinuation<Value>) {
       guard
         let data = try? storage.load(url),
-        data != stubBytes,
         !data.isEmpty
       else {
         continuation.resumeReturningInitialValue()
@@ -128,7 +127,7 @@
             // NB: Make sure there is a file to create a source for.
             if !storage.fileExists(url) {
               try storage.createDirectory(url.deletingLastPathComponent(), true)
-              try storage.save(stubBytes, url)
+              try storage.save(Data(), url)
             }
             let externalCancellable = try storage.fileSystemSource(url, [.write, .rename]) {
               [weak self] in
@@ -443,6 +442,4 @@
     #endif
     return encoder
   }()
-
-  private let stubBytes = Data("co.pointfree.Sharing.FileStorage.stub".utf8)
 #endif

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -17,7 +17,7 @@
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         #expect($users.loadError == nil)
         expectNoDifference(
-          fileSystem.value, [.fileURL: Data("co.pointfree.Sharing.FileStorage.stub".utf8)]
+          fileSystem.value, [.fileURL: Data()]
         )
         $users.withLock { $0.append(.blob) }
         try expectNoDifference(fileSystem.value.users(for: .fileURL), [.blob])
@@ -31,7 +31,7 @@
         @Shared(.utf8String) var string = ""
         #expect($string.loadError == nil)
         expectNoDifference(
-          fileSystem.value, [.utf8StringURL: Data("co.pointfree.Sharing.FileStorage.stub".utf8)]
+          fileSystem.value, [.utf8StringURL: Data()]
         )
         $string.withLock { $0 = "hello" }
         expectNoDifference(
@@ -317,7 +317,7 @@
           try await Task.sleep(nanoseconds: 1_200_000_000)
           expectNoDifference(users, [.blob])
           #expect(
-            try Data(contentsOf: .fileURL) == Data("co.pointfree.Sharing.FileStorage.stub".utf8)
+            try Data(contentsOf: .fileURL) == Data()
           )
         }
       }
@@ -440,7 +440,7 @@
     fileprivate func users(for url: URL) throws -> [User]? {
       guard
         let data = self[url],
-        data != Data("co.pointfree.Sharing.FileStorage.stub".utf8)
+        !data.isEmpty
       else { return nil }
       return try JSONDecoder().decode([User].self, from: data)
     }

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -374,7 +374,7 @@
       @MainActor
       @Test func multipleMutations() async throws {
         @Shared(.counts) var counts
-        let iterations = 10
+        let iterations = 1_000
         let buckets = 10
         for m in 1...iterations {
           for n in 1...buckets {

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -262,7 +262,6 @@
           try await Task.sleep(nanoseconds: 100_000_000)
           expectNoDifference(users, [])
 
-          try FileManager.default.removeItem(at: .fileURL)
           try FileManager.default.moveItem(at: .anotherFileURL, to: .fileURL)
           try await Task.sleep(nanoseconds: 1_000_000_000)
           expectNoDifference(users, [.blob])


### PR DESCRIPTION
There's a migration path from 0.x/1.x to 2.x where an empty file is on disk and the library tries to decode that. We can just resume with the default value when that happens.