### PR TITLE
Shared + map

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -613,6 +613,56 @@ where Base: MutableReference, Path: WritableKeyPath<Base.Value, Value> {
   }
 }
 
+final class _ReadClosureReference<Base: Reference, Value>:
+  Reference,
+  Observable
+{
+  private let base: Base
+  private let body: @Sendable (Base.Value) -> Value
+
+  init(base: Base, body: @escaping @Sendable (Base.Value) -> Value) {
+    self.base = base
+    self.body = body
+  }
+
+  var id: ObjectIdentifier {
+    base.id
+  }
+
+  var isLoading: Bool {
+    base.isLoading
+  }
+
+  var loadError: (any Error)? {
+    base.loadError
+  }
+
+  var wrappedValue: Value {
+    body(base.wrappedValue)
+  }
+
+  func load() async throws {
+    try await base.load()
+  }
+
+  func touch() {
+    base.touch()
+  }
+
+  #if canImport(Combine)
+    var publisher: any Publisher<Value, Never> {
+      func open(_ publisher: some Publisher<Base.Value, Never>) -> any Publisher<Value, Never> {
+        publisher.map(body)
+      }
+      return open(base.publisher)
+    }
+  #endif
+
+  var description: String {
+    ".map(\(base.description), as: \(Value.self).self)"
+  }
+}
+
 final class _OptionalReference<Base: Reference<Value?>, Value>:
   Reference,
   Observable,

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -223,6 +223,15 @@ public struct Shared<Value> {
       reference = newValue.reference
     }
   }
+  
+  /// Returns a read-only shared reference to the resulting value of a given closure.
+  ///
+  /// - Returns: A new read-only shared reference.
+  public func map<Member>(
+    _ body: @escaping @Sendable(Value) -> Member
+  ) -> SharedReader<Member> {
+    SharedReader(self).map(body)
+  }
 
   /// Returns a shared reference to the resulting value of a given key path.
   ///

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -227,7 +227,7 @@ public struct Shared<Value> {
   /// Returns a read-only shared reference to the resulting value of a given closure.
   ///
   /// - Returns: A new read-only shared reference.
-  public func map<Member>(
+  public func reader<Member>(
     _ body: @escaping @Sendable(Value) -> Member
   ) -> SharedReader<Member> {
     SharedReader(self).map(body)

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -227,10 +227,10 @@ public struct Shared<Value> {
   /// Returns a read-only shared reference to the resulting value of a given closure.
   ///
   /// - Returns: A new read-only shared reference.
-  public func reader<Member>(
+  public func read<Member>(
     _ body: @escaping @Sendable(Value) -> Member
   ) -> SharedReader<Member> {
-    SharedReader(self).map(body)
+    SharedReader(self).read(body)
   }
 
   /// Returns a shared reference to the resulting value of a given key path.

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -159,7 +159,7 @@ public struct SharedReader<Value> {
   /// Returns a read-only shared reference to the resulting value of a given closure.
   ///
   /// - Returns: A new shared reader.
-  public func map<Member>(
+  public func read<Member>(
     _ body: @escaping @Sendable (Value) -> Member
   ) -> SharedReader<Member> {
     func open(_ reference: some Reference<Value>) -> SharedReader<Member> {

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -155,6 +155,20 @@ public struct SharedReader<Value> {
       reference = newValue.reference
     }
   }
+  
+  /// Returns a read-only shared reference to the resulting value of a given closure.
+  ///
+  /// - Returns: A new shared reader.
+  public func map<Member>(
+    _ body: @escaping @Sendable (Value) -> Member
+  ) -> SharedReader<Member> {
+    func open(_ reference: some Reference<Value>) -> SharedReader<Member> {
+      SharedReader<Member>(
+        reference: _ReadClosureReference(base: reference, body: body)
+      )
+    }
+    return open(reference)
+  }
 
   /// Returns a read-only shared reference to the resulting value of a given key path.
   ///

--- a/Tests/SharingTests/EquatableTests.swift
+++ b/Tests/SharingTests/EquatableTests.swift
@@ -33,12 +33,12 @@ struct EquatableTests {
     #expect($lhs == $rhs)
   }
   
-  @Test func map() {
+  @Test func mapReader() {
     @Shared(value: 0) var base: Int
     @SharedReader var lhs: Int
     @SharedReader var rhs: Int
-    _lhs = $base.map { $0 * 2 }
-    _rhs = $base.map { $0 * 3 }
+    _lhs = $base.reader { $0 * 2 }
+    _rhs = $base.reader { $0 * 3 }
     #expect(lhs == rhs)
     #expect($lhs == $rhs)
     

--- a/Tests/SharingTests/EquatableTests.swift
+++ b/Tests/SharingTests/EquatableTests.swift
@@ -32,4 +32,18 @@ struct EquatableTests {
     #expect(lhs == rhs)
     #expect($lhs == $rhs)
   }
+  
+  @Test func map() {
+    @Shared(value: 0) var base: Int
+    @SharedReader var lhs: Int
+    @SharedReader var rhs: Int
+    _lhs = $base.map { $0 * 2 }
+    _rhs = $base.map { $0 * 3 }
+    #expect(lhs == rhs)
+    #expect($lhs == $rhs)
+    
+    $base.withLock { $0 += 1 }
+    #expect(lhs != rhs)
+    #expect($lhs != $rhs)
+  }
 }

--- a/Tests/SharingTests/EquatableTests.swift
+++ b/Tests/SharingTests/EquatableTests.swift
@@ -37,8 +37,8 @@ struct EquatableTests {
     @Shared(value: 0) var base: Int
     @SharedReader var lhs: Int
     @SharedReader var rhs: Int
-    _lhs = $base.reader { $0 * 2 }
-    _rhs = $base.reader { $0 * 3 }
+    _lhs = $base.read { $0 * 2 }
+    _rhs = $base.read { $0 * 3 }
     #expect(lhs == rhs)
     #expect($lhs == $rhs)
     

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -88,10 +88,10 @@ import Testing
       #expect(id == 42)
     }
     
-    @Test func map() {
+    @Test func mapReader() {
       @Shared(value: 0) var count
       @SharedReader var isZero: Bool
-      _isZero = $count.map { $0 == 0 }
+      _isZero = $count.reader { $0 == 0 }
 
       #expect(isZero)
 

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -91,7 +91,7 @@ import Testing
     @Test func mapReader() {
       @Shared(value: 0) var count
       @SharedReader var isZero: Bool
-      _isZero = $count.reader { $0 == 0 }
+      _isZero = $count.read { $0 == 0 }
 
       #expect(isZero)
 

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -87,6 +87,22 @@ import Testing
 
       #expect(id == 42)
     }
+    
+    @Test func map() {
+      @Shared(value: 0) var count
+      @SharedReader var isZero: Bool
+      _isZero = $count.map { $0 == 0 }
+
+      #expect(isZero)
+
+      $count.withLock { $0 += 1 }
+
+      #expect(!isZero)
+
+      $count = Shared(value: 0)
+
+      #expect(!isZero)
+    }
 
     @Test func optional() throws {
       @Shared(value: nil) var wrappedCount: Int?


### PR DESCRIPTION
Adding a `map` method to both Shared and SharedReader

**Motivation**

Avoid sharing parent feature logic with a child.

**E.g.**

```swift
// Feature
@Shared var selectedID: ID 
var children: IdentifiedArrayOf<Child>

// Child
@SharedReader var isSelected: Bool 

// Child Initial State
.init(isSelected: $selectedID.map { $0 == id })
```

**Note**

It could also be cool to add a writable map method, but I don't see the use case today