### PR TITLE
Don't report errors as issues in testing

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -254,9 +254,11 @@ final class _PersistentReference<Key: SharedReaderKey>:
       withMutation(keyPath: \._loadError) {
         lock.withLock { _loadError = newValue }
       }
-      if let newValue {
-        reportIssue(newValue)
-      }
+      #if DEBUG
+        if !isTesting, let newValue {
+          reportIssue(newValue)
+        }
+      #endif
     }
   }
 
@@ -371,9 +373,11 @@ extension _PersistentReference: MutableReference, Equatable where Key: SharedKey
       withMutation(keyPath: \._saveError) {
         lock.withLock { _saveError = newValue }
       }
-      if let newValue {
-        reportIssue(newValue)
-      }
+      #if DEBUG
+        if !isTesting, let newValue {
+          reportIssue(newValue)
+        }
+      #endif
     }
   }
 

--- a/Tests/SharingTests/ErrorThrowingTests.swift
+++ b/Tests/SharingTests/ErrorThrowingTests.swift
@@ -20,10 +20,8 @@ import Testing
       }
     }
     @Shared(Key()) var value = 0
-    await withKnownIssue {
-      await #expect(throws: SaveError.self) {
-        try await $value.save()
-      }
+    await #expect(throws: SaveError.self) {
+      try await $value.save()
     }
     #expect($value.saveError is SaveError)
   }
@@ -42,12 +40,8 @@ import Testing
       struct LoadError: Error {}
     }
 
-    withKnownIssue {
-      @SharedReader(Key()) var count = 0
-      #expect($count.loadError != nil)
-    } matching: {
-      $0.description == "Caught error: LoadError()"
-    }
+    @SharedReader(Key()) var count = 0
+    #expect($count.loadError != nil)
   }
   
   @Test func userInitiatedLoadError() async {
@@ -71,12 +65,8 @@ import Testing
     
     @SharedReader(Key()) var value = 0
     
-    await withKnownIssue {
-      await #expect(throws: LoadError.self) {
-        try await $value.load()
-      }
-    } matching: {
-      $0.description == "Caught error: LoadError()"
+    await #expect(throws: LoadError.self) {
+      try await $value.load()
     }
   }
 
@@ -117,11 +107,7 @@ import Testing
 
     let key = Key()
     @SharedReader(key) var count = 0
-    withKnownIssue {
-      key.subscriber?.yield(throwing: Key.LoadError())
-    } matching: {
-      $0.description == "Caught error: LoadError()"
-    }
+    key.subscriber?.yield(throwing: Key.LoadError())
     #expect($count.loadError != nil)
 
     key.subscriber?.yield(1)
@@ -147,11 +133,7 @@ import Testing
     }
 
     @Shared(Key()) var count = 0
-    withKnownIssue {
-      $count.withLock { $0 -= 1 }
-    } matching: {
-      $0.description == "Caught error: SaveError()"
-    }
+    $count.withLock { $0 -= 1 }
     #expect($count.saveError != nil)
 
     $count.withLock { $0 += 1 }
@@ -180,18 +162,10 @@ import Testing
 
     let key = Key()
     @Shared(key) var count = 0
-    withKnownIssue {
-      key.subscriber?.yield(throwing: Key.LoadError())
-    } matching: {
-      $0.description == "Caught error: LoadError()"
-    }
+    key.subscriber?.yield(throwing: Key.LoadError())
     #expect($count.loadError != nil)
 
-    withKnownIssue {
-      $count.withLock { $0 -= 1 }
-    } matching: {
-      $0.description == "Caught error: SaveError()"
-    }
+    $count.withLock { $0 -= 1 }
     #expect($count.loadError != nil)
     #expect($count.saveError != nil)
 
@@ -200,11 +174,7 @@ import Testing
     #expect($count.loadError == nil)
     #expect($count.saveError != nil)
 
-    withKnownIssue {
-      key.subscriber?.yield(throwing: Key.LoadError())
-    } matching: {
-      $0.description == "Caught error: LoadError()"
-    }
+    key.subscriber?.yield(throwing: Key.LoadError())
     #expect($count.loadError != nil)
     #expect($count.saveError != nil)
 
@@ -233,9 +203,7 @@ import Testing
     #expect($count.loadError == nil)
 
     struct LoadError: Error {}
-    withKnownIssue {
-      key.continuation.withLock { $0?.resume(throwing: LoadError()) }
-    }
+    key.continuation.withLock { $0?.resume(throwing: LoadError()) }
 
     #expect(!$count.isLoading)
     #expect($count.loadError != nil)
@@ -277,9 +245,7 @@ import Testing
     $count.withLock { $0 += 1 }
 
     struct SaveError: Error {}
-    withKnownIssue {
-      key.continuation.withLock { $0?.resume(throwing: SaveError()) }
-    }
+    key.continuation.withLock { $0?.resume(throwing: SaveError()) }
 
     #expect($count.saveError != nil)
 

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -136,15 +136,11 @@
       try withDependencies {
         $0.defaultFileStorage = .inMemory(fileSystem: fileSystem)
       } operation: {
-        try withKnownIssue {
-          @Shared(.fileStorage(.fileURL)) var users = [User]()
-          let loadError = try #require($users.loadError)
-          #expect(loadError is DecodingError)
-          $users.withLock { $0.append(User(id: 1, name: "Blob")) }
-          #expect($users.loadError == nil)
-        } matching: {
-          $0.error is DecodingError
-        }
+        @Shared(.fileStorage(.fileURL)) var users = [User]()
+        let loadError = try #require($users.loadError)
+        #expect(loadError is DecodingError)
+        $users.withLock { $0.append(User(id: 1, name: "Blob")) }
+        #expect($users.loadError == nil)
       }
     }
 
@@ -418,15 +414,7 @@
         try? FileManager.default.removeItem(at: .fileURL)
         try Data("corrupted".utf8).write(to: .fileURL)
         @Shared(value: 0) var count: Int
-        withKnownIssue {
-          $count = Shared(wrappedValue: 0, .fileStorage(.fileURL))
-        } matching: {
-          $0.description.hasPrefix("""
-            Caught error: dataCorrupted(Swift.DecodingError.Context(codingPath: [], \
-            debugDescription: "The given data was not valid JSON.", underlyingError: \
-            Optional(Error Domain=NSCocoaErrorDomain Code=3840 "Unexpected character
-            """)
-        }
+        $count = Shared(wrappedValue: 0, .fileStorage(.fileURL))
         #expect(count == 0)
         $count.withLock { $0 = 1 }
         try await Task.sleep(for: .seconds(0.01))


### PR DESCRIPTION
There are better ways to assert against shared errors, but it is still handy to surface these in DEBUG builds.