### PR TITLE
Add deprecated `Shared.read` overload, swift-format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,27 @@
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: format-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift_format:
+    name: swift-format
+    runs-on: macos-15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      - name: Format
+        run: make format
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Run swift-format
+          branch: 'main'

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -223,14 +223,23 @@ public struct Shared<Value> {
       reference = newValue.reference
     }
   }
-  
+
   /// Returns a read-only shared reference to the resulting value of a given closure.
   ///
   /// - Returns: A new read-only shared reference.
   public func read<Member>(
-    _ body: @escaping @Sendable(Value) -> Member
+    _ body: @escaping @Sendable (Value) -> Member
   ) -> SharedReader<Member> {
     SharedReader(self).read(body)
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Use dynamic member lookup instead ('$shared.member', not '$shared.read(\\.member)')"
+  )
+  public func read<Member>(_ keyPath: KeyPath<Value, Member>) -> SharedReader<Member> {
+    self[dynamicMember: keyPath]
   }
 
   /// Returns a shared reference to the resulting value of a given key path.

--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -559,20 +559,20 @@
     }
   }
 
-extension UserDefaults {
-  public static var inMemory: UserDefaults {
-    let suiteName: String
-    // NB: Due to a bug in iOS 16 and lower, UserDefaults does not observe changes when using
-    //     file-based suites. Go back to using temporary directory always when we drop iOS 16
-    //     support.
-    if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10, visionOS 1) {
-      suiteName = "co.pointfree.Sharing.\(UUID().uuidString)"
-    } else {
-      suiteName = "\(NSTemporaryDirectory())co.pointfree.Sharing.\(UUID().uuidString)"
+  extension UserDefaults {
+    public static var inMemory: UserDefaults {
+      let suiteName: String
+      // NB: Due to a bug in iOS 16 and lower, UserDefaults does not observe changes when using
+      //     file-based suites. Go back to using temporary directory always when we drop iOS 16
+      //     support.
+      if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10, visionOS 1) {
+        suiteName = "co.pointfree.Sharing.\(UUID().uuidString)"
+      } else {
+        suiteName = "\(NSTemporaryDirectory())co.pointfree.Sharing.\(UUID().uuidString)"
+      }
+      return UserDefaults(suiteName: suiteName)!
     }
-    return UserDefaults(suiteName: suiteName)!
   }
-}
 
   private enum AppStorageKeyFormatWarningEnabledKey: DependencyKey {
     static let liveValue = true

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -155,7 +155,7 @@ public struct SharedReader<Value> {
       reference = newValue.reference
     }
   }
-  
+
   /// Returns a read-only shared reference to the resulting value of a given closure.
   ///
   /// - Returns: A new shared reader.
@@ -168,6 +168,15 @@ public struct SharedReader<Value> {
       )
     }
     return open(reference)
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "Use dynamic member lookup instead ('$shared.member', not '$shared.read(\\.member)')"
+  )
+  public func read<Member>(_ keyPath: KeyPath<Value, Member>) -> SharedReader<Member> {
+    self[dynamicMember: keyPath]
   }
 
   /// Returns a read-only shared reference to the resulting value of a given key path.

--- a/Tests/SharingTests/ContinuationTests.swift
+++ b/Tests/SharingTests/ContinuationTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import Sharing
+import Testing
 
 @Suite struct ContinuationTests {
   @Test func dontResumeLoadContinuation() async throws {

--- a/Tests/SharingTests/EquatableTests.swift
+++ b/Tests/SharingTests/EquatableTests.swift
@@ -32,7 +32,7 @@ struct EquatableTests {
     #expect(lhs == rhs)
     #expect($lhs == $rhs)
   }
-  
+
   @Test func mapReader() {
     @Shared(value: 0) var base: Int
     @SharedReader var lhs: Int
@@ -41,7 +41,7 @@ struct EquatableTests {
     _rhs = $base.read { $0 * 3 }
     #expect(lhs == rhs)
     #expect($lhs == $rhs)
-    
+
     $base.withLock { $0 += 1 }
     #expect(lhs != rhs)
     #expect($lhs != $rhs)

--- a/Tests/SharingTests/ErrorThrowingTests.swift
+++ b/Tests/SharingTests/ErrorThrowingTests.swift
@@ -43,7 +43,7 @@ import Testing
     @SharedReader(Key()) var count = 0
     #expect($count.loadError != nil)
   }
-  
+
   @Test func userInitiatedLoadError() async {
     struct LoadError: Error {}
     struct Key: Hashable, Sendable, SharedReaderKey {
@@ -62,9 +62,9 @@ import Testing
         SharedSubscription {}
       }
     }
-    
+
     @SharedReader(Key()) var value = 0
-    
+
     await #expect(throws: LoadError.self) {
       try await $value.load()
     }

--- a/Tests/SharingTests/InMemoryTests.swift
+++ b/Tests/SharingTests/InMemoryTests.swift
@@ -86,7 +86,8 @@ import Testing
       @Shared(.inMemory("nestedOptionalCount")) var nestedOptionalCount: Int?? = .some(.none)
       #expect(nestedOptionalCount == .some(.none))
 
-      @SharedReader(.inMemory("nestedOptionalCountReader")) var nestedOptionalCountReader: Int?? = .some(.none)
+      @SharedReader(.inMemory("nestedOptionalCountReader")) var nestedOptionalCountReader: Int?? =
+        .some(.none)
       #expect(nestedOptionalCountReader == .some(.none))
     }
 

--- a/Tests/SharingTests/SharedChangeTrackerTests.swift
+++ b/Tests/SharingTests/SharedChangeTrackerTests.swift
@@ -98,7 +98,7 @@ import Testing
       $count.withLock { $0 = 1 }
 
       #expect($count == $count)
-      #expect(counts.withLock(\.self) == [0 ,1])
+      #expect(counts.withLock(\.self) == [0, 1])
     }
   }
 

--- a/Tests/SharingTests/SharedTests.swift
+++ b/Tests/SharingTests/SharedTests.swift
@@ -87,7 +87,7 @@ import Testing
 
       #expect(id == 42)
     }
-    
+
     @Test func mapReader() {
       @Shared(value: 0) var count
       @SharedReader var isZero: Bool


### PR DESCRIPTION
Just to avoid strange usage.

In the process I noticed swift-format missing from our infrastructure, so sneaking it in now.