### PR TITLE
Set up dispatch sources after external write.

### DIFF
--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -150,11 +150,7 @@
               [weak self] in
               guard let self else { return }
               let fileExists = self.storage.fileExists(self.url)
-              defer {
-                if !fileExists {
-                  setUpSources()
-                }
-              }
+              defer { setUpSources() }
               let modificationDate =
                 fileExists
                 ? (try? self.storage.attributesOfItemAtPath(self.url.path)[.modificationDate]

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -448,6 +448,23 @@
         try await Task.sleep(for: .seconds(1.5))
         #expect(count2 == 999)
       }
+
+      @Test func externalAtomicWrite() async throws {
+        @Shared(.fileStorage(.fileURL)) var count = 0
+
+        try Data("42".utf8).write(to: .fileURL, options: .atomic)
+        try await Task.sleep(for: .seconds(1.5))
+        #expect(count == 42)
+
+        try Data("1728".utf8).write(to: .fileURL, options: .atomic)
+        try await Task.sleep(for: .seconds(1.5))
+        #expect(count == 1728)
+
+        $count.withLock { $0 = 999 }
+        try await Task.sleep(for: .seconds(1.5))
+        #expect(count == 999)
+        #expect(try String(decoding: Data(contentsOf: .fileURL), as: UTF8.self) == "999")
+      }
     }
   }
 

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -431,11 +431,11 @@
         try? FileManager.default.removeItem(at: count2URL)
 
         @Shared(.fileStorage(count1URL)) var count1 = 0
-        @Shared(.fileStorage(count1URL)) var count2 = 0
+        @Shared(.fileStorage(count2URL)) var count2 = 0
 
         $count1.withLock { $0 = 42 }
         #expect(count1 == 42)
-        try await Task.sleep(for: .seconds(0.1))
+        try await Task.sleep(for: .seconds(1.5))
         #expect(count2 == 42)
 
         $count2.withLock { $0 = 1728 }


### PR DESCRIPTION
Fixes #147.

In #129 we made a change to support atomic writes of the file in `fileStorage`. We made the assumption that if a file is deleted but the file exists (as is the case for atomic writes since they are a write+move), then we don't need to recreate the dispatch source. That worked well when the write was internally performed, but if someone atomically writes to the file it causes us to not re-setup the dispatch source. Now we always set up the dispatch source after a write.