### PR TITLE
Fix deadlock when accessing `@Shared` in a `Dependency`

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -196,6 +196,7 @@ final class _PersistentReference<Key: SharedReaderKey>:
   private var _saveError: (any Error)?
   private var _referenceCount = 0
   private var subscription: SharedSubscription?
+  internal var onDeinit: (() -> Void)?
 
   init(key: Key, value initialValue: Key.Value, skipInitialLoad: Bool) {
     self.key = key
@@ -229,6 +230,10 @@ final class _PersistentReference<Key: SharedReaderKey>:
         onLoading: { [weak self] in self?.isLoading = $0 }
       )
     )
+  }
+
+  deinit {
+    onDeinit?()
   }
 
   var id: ObjectIdentifier { ObjectIdentifier(self) }
@@ -311,16 +316,6 @@ final class _PersistentReference<Key: SharedReaderKey>:
 
   func retain() {
     lock.withLock { _referenceCount += 1 }
-  }
-
-  func release() {
-    let shouldRelease = lock.withLock {
-      _referenceCount -= 1
-      return _referenceCount <= 0
-    }
-    guard shouldRelease else { return }
-    @Dependency(PersistentReferences.self) var persistentReferences
-    persistentReferences.removeReference(forKey: key)
   }
 
   func access<Member>(
@@ -451,85 +446,6 @@ extension _PersistentReference: MutableReference, Equatable where Key: SharedKey
 
   static func == (lhs: _PersistentReference, rhs: _PersistentReference) -> Bool {
     lhs === rhs
-  }
-}
-
-final class _ManagedReference<Key: SharedReaderKey>: Reference, Observable {
-  private let base: _PersistentReference<Key>
-
-  init(_ base: _PersistentReference<Key>) {
-    base.retain()
-    self.base = base
-  }
-
-  deinit {
-    base.release()
-  }
-
-  var id: ObjectIdentifier {
-    base.id
-  }
-
-  var isLoading: Bool {
-    base.isLoading
-  }
-
-  var loadError: (any Error)? {
-    base.loadError
-  }
-
-  var wrappedValue: Key.Value {
-    base.wrappedValue
-  }
-
-  func load() async throws {
-    try await base.load()
-  }
-
-  func touch() {
-    base.touch()
-  }
-
-  #if canImport(Combine)
-    var publisher: any Publisher<Key.Value, Never> {
-      base.publisher
-    }
-  #endif
-
-  var description: String {
-    base.description
-  }
-}
-
-extension _ManagedReference: MutableReference, Equatable where Key: SharedKey {
-  var saveError: (any Error)? {
-    base.saveError
-  }
-
-  var snapshot: Key.Value? {
-    base.snapshot
-  }
-
-  func takeSnapshot(
-    _ value: Key.Value,
-    fileID: StaticString,
-    filePath: StaticString,
-    line: UInt,
-    column: UInt
-  ) {
-    base.takeSnapshot(value, fileID: fileID, filePath: filePath, line: line, column: column)
-  }
-
-  func withLock<R>(_ body: (inout Key.Value) throws -> R) rethrows -> R {
-    try base.withLock(body)
-  }
-
-  func save() async throws {
-    try await base.save()
-  }
-
-  static func == (lhs: _ManagedReference, rhs: _ManagedReference) -> Bool {
-    lhs.base == rhs.base
   }
 }
 

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -194,7 +194,6 @@ final class _PersistentReference<Key: SharedReaderKey>:
   private var _isLoading = false
   private var _loadError: (any Error)?
   private var _saveError: (any Error)?
-  private var _referenceCount = 0
   private var subscription: SharedSubscription?
   internal var onDeinit: (() -> Void)?
 
@@ -312,10 +311,6 @@ final class _PersistentReference<Key: SharedReaderKey>:
     withMutation(keyPath: \._isLoading) {}
     withMutation(keyPath: \._loadError) {}
     withMutation(keyPath: \._saveError) {}
-  }
-
-  func retain() {
-    lock.withLock { _referenceCount += 1 }
   }
 
   func access<Member>(

--- a/Sources/Sharing/SharedContinuations.swift
+++ b/Sources/Sharing/SharedContinuations.swift
@@ -229,7 +229,7 @@ private final class ContinuationBox<Value>: Sendable {
         invoked. This will cause tasks waiting on it to resume immediately.
         """
       )
-      callback.withLock { $0?(.success(nil)) }
+      callback.withLock(\.self)?(.success(nil))
     }
   }
 
@@ -246,9 +246,10 @@ private final class ContinuationBox<Value>: Sendable {
       )
       return
     }
-    callback.withLock { callback in
+    let callback = callback.withLock { callback in
       defer { callback = nil }
-      callback?(result)
+      return callback
     }
+    callback?(result)
   }
 }

--- a/Sources/Sharing/SharedContinuations.swift
+++ b/Sources/Sharing/SharedContinuations.swift
@@ -210,7 +210,6 @@ public struct SaveContinuation: Sendable {
 private final class ContinuationBox<Value>: Sendable {
   private let callback: Mutex<(@Sendable (Result<Value?, any Error>) -> Void)?>
   private let description: @Sendable () -> String
-  private let resumeCount = Mutex(0)
 
   init(
     callback: @escaping @Sendable (Result<Value?, any Error>) -> Void,
@@ -221,24 +220,23 @@ private final class ContinuationBox<Value>: Sendable {
   }
 
   deinit {
-    let isComplete = resumeCount.withLock { $0 } > 0
-    if !isComplete {
+    if let callback = callback.withLock({ $0 }) {
       reportIssue(
         """
         \(description()) leaked its continuation without one of its resume methods being \
         invoked. This will cause tasks waiting on it to resume immediately.
         """
       )
-      callback.withLock(\.self)?(.success(nil))
+      callback(.success(nil))
     }
   }
 
   func resume(with result: Result<Value?, any Error>) {
-    let resumeCount = resumeCount.withLock {
-      $0 += 1
-      return $0
+    let callback = callback.withLock { callback in
+      defer { callback = nil }
+      return callback
     }
-    guard resumeCount == 1 else {
+    guard let callback else {
       reportIssue(
         """
         \(description()) tried to resume its continuation more than once.
@@ -246,10 +244,6 @@ private final class ContinuationBox<Value>: Sendable {
       )
       return
     }
-    let callback = callback.withLock { callback in
-      defer { callback = nil }
-      return callback
-    }
-    callback?(result)
+    callback(result)
   }
 }


### PR DESCRIPTION
As described in #149, there can be a deadlock when accessing `@Shared` in a `Dependency`. The issue still exists in the latest 2.5.0 release.

The deadlock occurs when:
- one thread (Thread 1) is holding `CachedValues.lock` in `DependencyValues.subcript.getter` while initialising a `liveValue` involving a local `@Shared` variable which needs to lock `PersistentReferences.lock` ,
- while [another thread](https://github.com/pointfreeco/swift-sharing/blob/2.5.0/Sources/Sharing/Internal/PersistentReferences.swift#L22-L29) (Thread 7) is doing it the other way, holding `PersistentReferences.lock` during the call to `_PersistentReference<Key>.init` which ultimately [attempts to lock](https://github.com/pointfreeco/swift-dependencies/blob/1.9.2/Sources/Dependencies/DependencyValues.swift#L501) `CachedValues.lock`.
- (there's also some more locking involved in `SharedContinuations.swift`, which doesn't cause this deadlock but does not need to be held that long).

| Thread 1 | Thread 7 |
|--|--|
| <img width="610" alt="Thread 1" src="https://github.com/user-attachments/assets/78fe423d-5746-43ec-88fe-163e5065de7e" /> | <img width="606" alt="Thread 7" src="https://github.com/user-attachments/assets/50e7ce94-9e4a-4781-b5d9-d33eb358272a" /> |

This PR changes `swift-sharing` to avoid holding locks of its own while accessing `@Dependency`, in order to keep the locking order the same: `swift-sharing` locks them last (and releases first).

At the same time, some of the bookkeeping and reference counting logic got simplified.