### PR TITLE
Avoid extra MainActor hop from `Shared[Reader].load(_:)`

### DIFF
--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -88,17 +88,15 @@ extension Shared {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
   public func load(_ key: some SharedKey<Value>) async throws {
-    await MainActor.run {
-      @Dependency(PersistentReferences.self) var persistentReferences
-      SharedPublisherLocals.$isLoading.withValue(true) {
-        projectedValue = Shared(
-          reference: persistentReferences.value(
-            forKey: key,
-            default: wrappedValue,
-            skipInitialLoad: true
-          )
+    @Dependency(PersistentReferences.self) var persistentReferences
+    SharedPublisherLocals.$isLoading.withValue(true) {
+      projectedValue = Shared(
+        reference: persistentReferences.value(
+          forKey: key,
+          default: wrappedValue,
+          skipInitialLoad: true
         )
-      }
+      )
     }
     try await load()
   }

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -154,17 +154,15 @@ extension SharedReader {
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
   public func load(_ key: some SharedReaderKey<Value>) async throws {
-    await MainActor.run {
-      @Dependency(PersistentReferences.self) var persistentReferences
-      SharedPublisherLocals.$isLoading.withValue(true) {
-        projectedValue = SharedReader(
-          reference: persistentReferences.value(
-            forKey: key,
-            default: wrappedValue,
-            skipInitialLoad: true
-          )
+    @Dependency(PersistentReferences.self) var persistentReferences
+    SharedPublisherLocals.$isLoading.withValue(true) {
+      projectedValue = SharedReader(
+        reference: persistentReferences.value(
+          forKey: key,
+          default: wrappedValue,
+          skipInitialLoad: true
         )
-      }
+      )
     }
     try await load()
   }


### PR DESCRIPTION
A drive-by observation while reading code, it doesn't seem necessary to hop to `MainActor` in the body of `Shared[Reader].load(_:)`.