### PR TITLE
Publishers send the latest shared value for new subscriptions.

### DIFF
--- a/Sources/Sharing/SharedPublisher.swift
+++ b/Sources/Sharing/SharedPublisher.swift
@@ -15,9 +15,9 @@
     /// }
     /// ```
     public var publisher: some Publisher<Value, Never> {
-      box.subject
-        .handleEvents(receiveSubscription: { [box] _ in _ = box })
-        .prepend(wrappedValue)
+      Just<Void>(()).flatMap { _ in
+        box.subject.prepend(wrappedValue)
+      }
     }
   }
 
@@ -35,9 +35,9 @@
     /// }
     /// ```
     public var publisher: some Publisher<Value, Never> {
-      box.subject
-        .handleEvents(receiveSubscription: { [box] _ in _ = box })
-        .prepend(wrappedValue)
+      Just<Void>(()).flatMap { _ in
+        box.subject.prepend(wrappedValue)
+      }
     }
   }
 #endif


### PR DESCRIPTION
Fixes #160.

At the time of writing, the [current implementation of `Sharing.publisher` on `main`](https://github.com/pointfreeco/swift-sharing/blob/8f8fef0279ed6e71a166cedc870dcd422bb24a6c/Sources/Sharing/SharedPublisher.swift) looks like this:
```
    public var publisher: some Publisher<Value, Never> {
      box.subject
        .handleEvents(receiveSubscription: { [box] _ in _ = box })
        .prepend(wrappedValue)
    }
```

I approached this API expecting new subscribers of the returned publisher to receive the latest shared value. However, new subscribers receive the shared value at the time the publisher was created. Those new subscribers will receive the next shared value after. To my mind, this behaviour is counterintuitive.

Please see #160 for more detail.

Slack thread: https://pointfreecommunity.slack.com/archives/C0837DJJFA9/p1746759794786839