### PR TITLE
File storage: migrate stub data to empty files

### DIFF
--- a/Sources/Sharing/Internal/Deprecations.swift
+++ b/Sources/Sharing/Internal/Deprecations.swift
@@ -1,3 +1,19 @@
+#if canImport(Foundation)
+  import Foundation
+#endif
+
+// NB: Deprecated after 2.5.2
+
+#if canImport(Foundation)
+  @available(iOS, deprecated: 9999, message: "This will be removed in Sharing 3.")
+  @available(macOS, deprecated: 9999, message: "This will be removed in Sharing 3.")
+  @available(tvOS, deprecated: 9999, message: "This will be removed in Sharing 3.")
+  @available(watchOS, deprecated: 9999, message: "This will be removed in Sharing 3.")
+  extension Data {
+    package static let stub = Self("co.pointfree.Sharing.FileStorage.stub".utf8)
+  }
+#endif
+
 // NB: Deprecated after 2.2.0
 
 extension SharedReader {

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -375,7 +375,12 @@
         }
       },
       load: { url in
-        try Data(contentsOf: url)
+        var data = try Data(contentsOf: url)
+        if data == .stub {
+          data = Data()
+          try data.write(to: url, options: .atomic)
+        }
+        return data
       },
       save: { data, url in
         try data.write(to: url, options: .atomic)

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -408,6 +408,16 @@
         try Data().write(to: .fileURL)
         @Shared(.fileStorage(.fileURL)) var count = 0
         #expect(count == 0)
+        #expect($count.loadError == nil)
+      }
+
+      @Test func stubData() throws {
+        try? FileManager.default.removeItem(at: .fileURL)
+        try Data.stub.write(to: .fileURL)
+        @Shared(.fileStorage(.fileURL)) var count = 0
+        #expect(count == 0)
+        #expect($count.loadError == nil)
+        #expect(try Data(contentsOf: .fileURL).isEmpty)
       }
 
       @Test func corruptData() async throws {

--- a/Tests/SharingTests/PublisherTests.swift
+++ b/Tests/SharingTests/PublisherTests.swift
@@ -2,7 +2,7 @@
   import Combine
   import Dependencies
   import Foundation
-  @testable import Sharing
+  import Sharing
   import Testing
 
   @MainActor


### PR DESCRIPTION
Old clients may have stub files still around, so let's migrate them instead of emit errors. We can consider removing this migration logic at a later time

Fixes #163.