### PR TITLE
Document parameterized tests isolation

### DIFF
--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f6c228798eaec3678dc2f13373dc2173e70bafef60b3a8ada9dd6bed58d47174",
+  "originHash" : "0457435beb7093f1f55bafbafae9b81d3fe105d1ff4a77016fe15dc702bcf5ce",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -71,15 +71,6 @@
       "state" : {
         "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
         "version" : "8.0.2"
-      }
-    },
-    {
-      "identity" : "grdb.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/groue/GRDB.swift",
-      "state" : {
-        "branch" : "GRDB7",
-        "revision" : "3ecb5c54553559217592d21a6d9841becb891b38"
       }
     },
     {
@@ -195,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "6054df64b55186f08b6d0fd87152081b8ad8d613",
-        "version" : "1.2.0"
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
       }
     },
     {
@@ -213,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "7d2eb4ad20efb2838269645410d26b64ca48d8aa",
-        "version" : "1.6.1"
+        "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
+        "version" : "1.9.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "500737ab81f988e0ede3595eaafbe666038f9df1bba0e54c76826363e792e9c2",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -50,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "7d2eb4ad20efb2838269645410d26b64ca48d8aa",
-        "version" : "1.6.1"
+        "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
+        "version" : "1.9.2"
       }
     },
     {
@@ -109,5 +110,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/Sharing/Documentation.docc/Articles/Testing.md
+++ b/Sources/Sharing/Documentation.docc/Articles/Testing.md
@@ -49,6 +49,49 @@ The same holds true for the [`fileStorage`](<doc:SharedReaderKey/fileStorage(_:d
 and [`inMemory`](<doc:SharedReaderKey/inMemory(_:)>) strategies. Even though those strategies do
 interact with a global store of data, they do so in a way that is quarantined from other tests.
 
+### Testing parameterized tests
+
+Parameterized tests require special consideration when using `@Shared` values. Because parameterized 
+tests execute concurrently by default, multiple test instances that use the same shared key will 
+access the same underlying storage, which can lead to unexpected test failures.
+
+Consider this parameterized test:
+
+```swift
+@Test(arguments: 0...10)
+func testCounter(initialValue: Int) async throws {
+  @Shared(.inMemory("count")) var counter = initialValue
+  #expect(counter == initialValue)
+}
+```
+
+This test will fail non-deterministically because all concurrent test instances share the same 
+`.inMemory("count")` storage. The first test instance to execute will set the value, and all 
+subsequent instances will receive that value rather than their own `initialValue`.
+
+To properly isolate shared state in parameterized tests, use the `.dependencies` trait from the
+DependenciesTestSupport module. This trait quarantines a test's dependencies from other tests,
+ensuring that dependencies used within a suite or test are kept separate from any other suites
+and tests running in parallel:
+
+```swift
+import DependenciesTestSupport
+
+@Suite(.dependencies)
+struct CounterTests {
+  @Test(arguments: 0...10)
+  func testCounter(initialValue: Int) async throws {
+    @Shared(.inMemory("count")) var counter = initialValue
+    #expect(counter == initialValue)
+  }
+}
+```
+
+Since `@Shared` values are managed through the dependencies system, the `.dependencies` trait ensures
+that each test case receives its own isolated storage. This allows parameterized tests to execute 
+concurrently without interference, maintaining the same deterministic behavior you would expect from
+non-parameterized tests.
+
 ### Testing when using custom persistence strategies
 
 When creating your own custom persistence strategies you must be careful to do so in a style that

--- a/Tests/SharingTests/ParametrizedTests.swift
+++ b/Tests/SharingTests/ParametrizedTests.swift
@@ -1,0 +1,18 @@
+//
+//  Test.swift
+//  swift-sharing
+//
+//  Created by Hugo Saynac on 09/07/2025.
+//
+import Testing
+import Sharing
+import DependenciesTestSupport
+
+@Suite(.dependencies)
+struct MyTests {
+  @Test(arguments: 0...10)
+  func testCounterWithArguments(initialValue: Int) async throws {
+    @Shared(.inMemory("count")) var counter = initialValue
+    #expect(counter == initialValue)
+  }
+}

--- a/Tests/SharingTests/ParametrizedTests.swift
+++ b/Tests/SharingTests/ParametrizedTests.swift
@@ -1,12 +1,6 @@
-//
-//  Test.swift
-//  swift-sharing
-//
-//  Created by Hugo Saynac on 09/07/2025.
-//
-import Testing
-import Sharing
 import DependenciesTestSupport
+import Sharing
+import Testing
 
 @Suite(.dependencies)
 struct MyTests {


### PR DESCRIPTION
## Fix parameterized tests with @Shared values

### Problem
When using `@Shared` values in parameterized tests, test instances share the same
underlying storage, causing non-deterministic failures. For example:

  ```swift
@Test(arguments: 0...10)
func testCounter(initialValue: Int) async throws {
  @Shared(.inMemory("count")) var counter = initialValue
  #expect(counter == initialValue) // Fails when tests run concurrently
}
```
Only the first test instance to execute sets the initial value, and all subsequent
instances receive that value instead of their own initialValue.

  ### Solution

Document the use of .dependencies trait from DependenciesTestSupport, which
quarantines each test's dependencies and provides isolated storage for @Shared
values:

``` swift
@Suite(.dependencies)
struct CounterTests {
  @Test(arguments: 0...10)
  func testCounter(initialValue: Int) async throws {
    @Shared(.inMemory("count")) var counter = initialValue
    #expect(counter == initialValue) // Always passes
  }
}
```

###  Changes

- Added new section "Testing parameterized tests" to Testing.md documentation
- Explained why parameterized tests fail with shared state
- Documented the .dependencies trait as the recommended solution
- Provided clear code examples demonstrating the problem and solution

This makes the solution more discoverable for users encountering issues with
parameterized tests and @Shared state.