### PR TITLE
Close file handle in cancellation handler to avoid race

### DIFF
--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -352,10 +352,12 @@
           queue: DispatchQueue.main
         )
         source.setEventHandler(handler: $2)
+        source.setCancelHandler {
+          close(source.handle)
+        }
         source.resume()
         return SharedSubscription {
           source.cancel()
-          close(source.handle)
         }
       },
       load: { url in


### PR DESCRIPTION
This should fix https://github.com/pointfreeco/swift-sharing/issues/172 and implements the file handle closing as recommended in the Apple documentation.