### PR TITLE
Disfavor `appStorage`'s codable strategies

### DIFF
--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -109,13 +109,14 @@
       AppStorageKey(key, store: store)
     }
     
-    /// Creates a shared key that can read and write a Codable value to user defaults.
+    /// Creates a shared key that can read and write a codable value to user defaults.
     ///
     /// - Parameters:
     ///   - key: The key to read and write the value to in the user defaults store.
     ///   - store: The user defaults store to read and write to. A value of `nil` will use the user
     ///     default store from dependencies.
     /// - Returns: A user defaults shared key.
+    @_disfavoredOverload
     public static func appStorage<Value: Codable>(
       _ key: String, store: UserDefaults? = nil
     ) -> Self
@@ -249,13 +250,14 @@
       AppStorageKey(key, store: store)
     }
     
-    /// Creates a shared key that can read and write a Codable value to user defaults.
+    /// Creates a shared key that can read and write a codable value to user defaults.
     ///
     /// - Parameters:
     ///   - key: The key to read and write the value to in the user defaults store.
     ///   - store: The user defaults store to read and write to. A value of `nil` will use the user
     ///     default store from dependencies.
     /// - Returns: A user defaults shared key.
+    @_disfavoredOverload
     public static func appStorage<Value: Codable>(
       _ key: String, store: UserDefaults? = nil
     ) -> Self
@@ -373,7 +375,7 @@
     fileprivate init(_ key: String, store: UserDefaults?) where Value == Date {
       self.init(lookup: CastableLookup(), key: key, store: store)
     }
-    
+
     fileprivate init(_ key: String, store: UserDefaults?) where Value: Codable {
       self.init(lookup: CodableLookup(), key: key, store: store)
     }

--- a/Tests/SharingTests/AppStorageTests.swift
+++ b/Tests/SharingTests/AppStorageTests.swift
@@ -104,6 +104,16 @@
       #expect(id == ID(rawValue: "Blob, Jr."))
     }
 
+    @Test func rawRepresentableCodableString() {
+      struct ID: Codable, RawRepresentable {
+        var rawValue: String
+      }
+      @Shared(.appStorage("raw-representable-string")) var id = ID(rawValue: "Blob")
+      #expect(store.string(forKey: "raw-representable-string") == "Blob")
+      store.set("Blob, Jr.", forKey: "raw-representable-string")
+      #expect(id == ID(rawValue: "Blob, Jr."))
+    }
+
     @Test func optional() {
       @Shared(.appStorage("bool")) var bool: Bool?
       #expect(store.value(forKey: "bool") == nil)


### PR DESCRIPTION
In the case in which they overlap `RawRepresentable` we should favor `RawRepresentable`, which preserves existing behavior and is more performant and succinct in storage.

Fixes #184.