### PR TITLE
Add `CustomReflectable` conformances

### DIFF
--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -412,6 +412,12 @@ public struct Shared<Value> {
   }
 }
 
+extension Shared: CustomReflectable {
+  public var customMirror: Mirror {
+    Mirror(reflecting: wrappedValue)
+  }
+}
+
 extension Shared: CustomStringConvertible {
   public var description: String {
     "\(typeName(Self.self, genericsAbbreviated: false))(\(reference.description))"

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -301,6 +301,12 @@ public struct SharedReader<Value> {
   }
 }
 
+extension SharedReader: CustomReflectable {
+  public var customMirror: Mirror {
+    Mirror(reflecting: wrappedValue)
+  }
+}
+
 extension SharedReader: CustomStringConvertible {
   public var description: String {
     "\(typeName(Self.self, genericsAbbreviated: false))(\(reference.description))"


### PR DESCRIPTION
Prevents leaking any of the guts of a shared value.