### PR TITLE
Fix example in testing documentation

### DIFF
--- a/Sources/Sharing/Documentation.docc/Articles/Testing.md
+++ b/Sources/Sharing/Documentation.docc/Articles/Testing.md
@@ -129,8 +129,8 @@ value provided by the library:
 @main
 struct EntryPoint: App {
   var body: some Scene {
-    if !isTesting {
-      WindowGroup {
+    WindowGroup {
+      if !isTesting {
         // ...
       }
     }


### PR DESCRIPTION
The example here doesn't compile because [SceneBuilder specifically only supports `if` blocks for compiler availability checks](https://developer.apple.com/documentation/swiftui/scenebuilder/buildoptional(_:)).

This change matches the example in [swift-dependencies](https://github.com/pointfreeco/swift-dependencies/blob/3ba58ac404629ff48fd1b496081c4220b0ccae7f/Sources/Dependencies/Documentation.docc/Articles/Testing.md?plain=1#L229).