### PR TITLE
feat: Expose reference APIs

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -7,7 +7,7 @@ import PerceptionCore
   import Combine
 #endif
 
-@_spi(Internals)
+@_spi(References)
 public protocol Reference<Value>:
   AnyObject,
   CustomStringConvertible,
@@ -27,7 +27,7 @@ public protocol Reference<Value>:
   #endif
 }
 
-@_spi(Internals)
+@_spi(References)
 public protocol MutableReference<Value>: Reference, Equatable {
   var saveError: (any Error)? { get }
   var snapshot: Value? { get }

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -7,7 +7,8 @@ import PerceptionCore
   import Combine
 #endif
 
-protocol Reference<Value>:
+@_spi(Internals)
+public protocol Reference<Value>:
   AnyObject,
   CustomStringConvertible,
   Sendable,
@@ -26,7 +27,8 @@ protocol Reference<Value>:
   #endif
 }
 
-protocol MutableReference<Value>: Reference, Equatable {
+@_spi(Internals)
+public protocol MutableReference<Value>: Reference, Equatable {
   var saveError: (any Error)? { get }
   var snapshot: Value? { get }
   func withLock<R>(_ body: (inout Value) throws -> R) rethrows -> R

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -21,7 +21,8 @@ public struct Shared<Value> {
     @State private var generation = 0
   #endif
 
-  var reference: any MutableReference<Value> {
+  @_spi(Internals)
+  public var reference: any MutableReference<Value> {
     @storageRestrictions(initializes: box)
     init(initialValue) { box = Box(initialValue) }
     get { box.reference }

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -21,7 +21,7 @@ public struct Shared<Value> {
     @State private var generation = 0
   #endif
 
-  @_spi(Internals)
+  @_spi(References)
   public var reference: any MutableReference<Value> {
     @storageRestrictions(initializes: box)
     init(initialValue) { box = Box(initialValue) }

--- a/Sources/Sharing/SharedBinding.swift
+++ b/Sources/Sharing/SharedBinding.swift
@@ -42,7 +42,8 @@
   }
 
   extension MutableReference {
-    fileprivate var _wrappedValue: Value {
+    @_spi(Internals)
+    public var _wrappedValue: Value {
       get { wrappedValue }
       set { withLock { $0 = newValue } }
     }

--- a/Sources/Sharing/SharedBinding.swift
+++ b/Sources/Sharing/SharedBinding.swift
@@ -42,7 +42,7 @@
   }
 
   extension MutableReference {
-    @_spi(Internals)
+    @_spi(References)
     public var _wrappedValue: Value {
       get { wrappedValue }
       set { withLock { $0 = newValue } }


### PR DESCRIPTION
Exposing APIs required for [swift-navigation](https://github.com/pointfreeco/swift-navigation) `SwiftNavigationSharing` trait

> [!NOTE]
>
> _Follow up PR for https://github.com/pointfreeco/swift-composable-architecture/discussions/3865_

> [!NOTE]
>
> _Required for https://github.com/pointfreeco/swift-navigation/pull/331_
> _Since no public APIs were changed I binded the PR above to a patch update `2.7.5`_