### PR TITLE
Add an SPI `UIBinding` root for `Shared`

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -29,6 +29,7 @@ protocol Reference<Value>:
 protocol MutableReference<Value>: Reference, Equatable {
   var saveError: (any Error)? { get }
   var snapshot: Value? { get }
+  func _untrackedWrappedValue() -> Value
   func withLock<R>(_ body: (inout Value) throws -> R) rethrows -> R
   func takeSnapshot(
     _ value: Value,
@@ -118,6 +119,10 @@ final class _BoxReference<Value>: MutableReference, Observable, Perceptible, @un
     try withMutation(keyPath: \.value) {
       try lock.withLock { try body(&value) }
     }
+  }
+
+  func _untrackedWrappedValue() -> Value {
+    lock.withLock { value }
   }
 
   func save() {}
@@ -416,6 +421,10 @@ extension _PersistentReference: MutableReference, Equatable where Key: SharedKey
     }
   }
 
+  func _untrackedWrappedValue() -> Key.Value {
+    lock.withLock { value }
+  }
+
   func save() async throws {
     if _saveError != nil { saveError = nil }
     do {
@@ -514,6 +523,10 @@ where Base: MutableReference, Path: WritableKeyPath<Base.Value, Value> {
 
   func withLock<R>(_ body: (inout Value) throws -> R) rethrows -> R {
     try base.withLock { try body(&$0[keyPath: keyPath as WritableKeyPath]) }
+  }
+
+  func _untrackedWrappedValue() -> Value {
+    base._untrackedWrappedValue()[keyPath: keyPath as WritableKeyPath]
   }
 
   func save() async throws {
@@ -658,6 +671,14 @@ extension _OptionalReference: MutableReference, Equatable where Base: MutableRef
       }
       return try body(&unwrapped)
     }
+  }
+
+  func _untrackedWrappedValue() -> Value {
+    guard let wrappedValue = base._untrackedWrappedValue() else {
+      return lock.withLock { cachedValue }
+    }
+    lock.withLock { cachedValue = wrappedValue }
+    return wrappedValue
   }
 
   func save() async throws {

--- a/Sources/Sharing/Internal/SharedUIBindingRoot.swift
+++ b/Sources/Sharing/Internal/SharedUIBindingRoot.swift
@@ -1,0 +1,63 @@
+import Foundation
+import PerceptionCore
+
+@_spi(Navigation) extension Shared {
+  public var _uiBindingRoot: _SharedUIBindingRoot<Value> {
+    box.uiBindingRoot
+  }
+}
+
+@_spi(Navigation) public final class _SharedUIBindingRoot<Value>: Perceptible, @unchecked Sendable {
+  private let _$perceptionRegistrar = PerceptionRegistrar()
+  private let lock = NSRecursiveLock()
+  private var reference: any MutableReference<Value>
+
+  init(reference: any MutableReference<Value>) {
+    self.reference = reference
+    observeReference()
+  }
+
+  public var value: Value {
+    get {
+      _$perceptionRegistrar.access(self, keyPath: \.value)
+      lock.lock()
+      let reference = self.reference
+      lock.unlock()
+      return reference._untrackedWrappedValue()
+    }
+    set {
+      lock.lock()
+      let reference = self.reference
+      lock.unlock()
+      reference.withLock { $0 = newValue }
+    }
+  }
+
+  func setReference(_ newReference: any MutableReference<Value>) {
+    let didChange = lock.withLock {
+      guard reference.id != newReference.id else { return false }
+      reference = newReference
+      return true
+    }
+    guard didChange else { return }
+    observeReference()
+    _$perceptionRegistrar.withMutation(of: self, keyPath: \.value) {}
+  }
+
+  private func observeReference() {
+    lock.lock()
+    let reference = self.reference
+    lock.unlock()
+    withPerceptionTracking {
+      _ = reference.wrappedValue
+    } onChange: { [weak self] in
+      guard let self else { return }
+      self._$perceptionRegistrar.withMutation(of: self, keyPath: \.value) {}
+      self.observeReference()
+    }
+  }
+}
+
+#if canImport(Observation)
+  extension _SharedUIBindingRoot: Observable {}
+#endif

--- a/Sources/Sharing/Shared.swift
+++ b/Sources/Sharing/Shared.swift
@@ -357,6 +357,7 @@ public struct Shared<Value> {
   final class Box: @unchecked Sendable {
     private let lock = NSRecursiveLock()
     private var _reference: any MutableReference<Value>
+    private var _uiBindingRoot: _SharedUIBindingRoot<Value>?
     #if canImport(Combine)
       let subject = PassthroughRelay<Value>()
       private var subjectCancellable: AnyCancellable
@@ -377,6 +378,7 @@ public struct Shared<Value> {
         #if canImport(Combine)
           subjectCancellable = _reference.publisher.subscribe(subject)
         #endif
+        _uiBindingRoot?.setReference(_reference)
       }
       set {
         lock.withLock {
@@ -384,7 +386,18 @@ public struct Shared<Value> {
           #if canImport(Combine)
             subjectCancellable = _reference.publisher.subscribe(subject)
           #endif
+          _uiBindingRoot?.setReference(newValue)
         }
+      }
+    }
+    var uiBindingRoot: _SharedUIBindingRoot<Value> {
+      lock.withLock {
+        if let _uiBindingRoot {
+          return _uiBindingRoot
+        }
+        let root = _SharedUIBindingRoot(reference: _reference)
+        _uiBindingRoot = root
+        return root
       }
     }
     init(_ reference: any MutableReference<Value>) {

--- a/Tests/SharingTests/SharedUIBindingRootTests.swift
+++ b/Tests/SharingTests/SharedUIBindingRootTests.swift
@@ -1,0 +1,23 @@
+@_spi(Navigation) import Sharing
+import Testing
+
+@Suite struct SharedUIBindingRootTests {
+  @Test func uiBindingRootIsStablePerSharedBox() {
+    @Shared(value: 0) var count
+
+    #expect($count._uiBindingRoot === $count._uiBindingRoot)
+  }
+
+  @Test func uiBindingRootTracksSharedReassignment() {
+    @Shared(value: 0) var count
+    let root = $count._uiBindingRoot
+    let next = Shared(value: 10)
+
+    $count = next
+    #expect(root.value == 10)
+
+    root.value = 11
+    #expect(root.value == 11)
+    #expect(next.wrappedValue == 11)
+  }
+}


### PR DESCRIPTION
Cache a UIBinding bridge root on Shared.Box so repeated bridges share identity and continue following reference reassignment.

Add an internal untracked read path for mutable references so the bridge root remains the only observation boundary and does not trigger duplicate invalidations.

Cover the SPI root with Swift Testing.

Related to https://github.com/pointfreeco/swift-navigation/pull/340.