### PR TITLE
Fix data race in _PersistentReference.withLock

### DIFF
--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -393,28 +393,26 @@ extension _PersistentReference: MutableReference, Equatable where Key: SharedKey
 
   func withLock<R>(_ body: (inout Key.Value) throws -> R) rethrows -> R {
     try withMutation(keyPath: \.value) {
-      var savedValue = value
-      defer {
-        let key = key
-        key.save(
-          savedValue,
-          context: .didSet,
-          continuation: SaveContinuation("\(key)") { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success:
-              if _loadError != nil { loadError = nil }
-              if _saveError != nil { saveError = nil }
-            case let .failure(error):
-              saveError = error
-            }
+      let (result, modifiedValue) = try lock.withLock {
+        let result = try body(&value)
+        return (result, value)
+      }
+      let key = key
+      key.save(
+        modifiedValue,
+        context: .didSet,
+        continuation: SaveContinuation("\(key)") { [weak self] result in
+          guard let self else { return }
+          switch result {
+          case .success:
+            if _loadError != nil { loadError = nil }
+            if _saveError != nil { saveError = nil }
+          case let .failure(error):
+            saveError = error
           }
-        )
-      }
-      return try lock.withLock {
-        defer { savedValue = value }
-        return try body(&value)
-      }
+        }
+      )
+      return result
     }
   }
 

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -393,10 +393,11 @@ extension _PersistentReference: MutableReference, Equatable where Key: SharedKey
 
   func withLock<R>(_ body: (inout Key.Value) throws -> R) rethrows -> R {
     try withMutation(keyPath: \.value) {
+      var savedValue = value
       defer {
         let key = key
         key.save(
-          value,
+          savedValue,
           context: .didSet,
           continuation: SaveContinuation("\(key)") { [weak self] result in
             guard let self else { return }
@@ -411,7 +412,8 @@ extension _PersistentReference: MutableReference, Equatable where Key: SharedKey
         )
       }
       return try lock.withLock {
-        try body(&value)
+        defer { savedValue = value }
+        return try body(&value)
       }
     }
   }


### PR DESCRIPTION
We saw this super-hard-to-repro crash for a few users (it basically returns a 21 PB allocation for the buffer count because something gets corrupted along the way).

The defer block was reading self.value without holding the lock to pass to key.save. Another thread could acquire the lock and write a new value concurrently.

This fix captures the value under the lock using an inner defer so it is captured on both the success and throwing paths, preserving existing semantics.
