### PR TITLE
Fix FileStorageKey dropping writes under an immediate scheduler

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2d35c0c3e737b76f5d253977c3cab7b3210ea33058a79bc2ee0aa80767457fbc",
+  "originHash" : "83059f52cdf577161f89370a45ecc4973ccc4f0d8507a09cc5edcca6a358386e",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
         "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
-        "version" : "1.7.3"
       }
     },
     {

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -210,49 +210,59 @@
 
     public func save(_ value: Value, context: SaveContext, continuation: SaveContinuation) {
       do {
-        try state.withValue { state in
+        // NB: The work item is scheduled _outside_ of the 'state' lock below. Were it scheduled
+        //     inside, an immediate scheduler (as used by the in-memory test storage) would run it
+        //     re-entrantly while 'state.withValue' still holds a copy of the state. The outer
+        //     scope's write-back would then clobber the 'state.workItem = nil' performed by the
+        //     re-entrant work item, permanently pinning the key in its debounced branch so that
+        //     every subsequent '.didSet' save buffers without ever persisting.
+        let workItem = try state.withValue { state -> DispatchWorkItem? in
           let data = try encode(value)
           switch context {
           case .didSet:
-            if state.workItem == nil {
-              try save(data: data, url: url, modificationDates: &state.modificationDates)
-              continuation.resume()
-              let workItem = DispatchWorkItem { [weak self] in
-                guard let self else { return }
-                self.state.withValue { state in
-                  defer {
-                    state.value = nil
-                    state.workItem = nil
-                  }
-                  guard
-                    let value = state.value,
-                    let data = try? self.encode(value)
-                  else { return }
-                  let result = Result {
-                    try self.save(
-                      data: data,
-                      url: self.url,
-                      modificationDates: &state.modificationDates
-                    )
-                  }
-                  for continuation in state.continuations {
-                    continuation.resume(with: result)
-                  }
-                  state.continuations.removeAll()
-                }
-              }
-              state.workItem = workItem
-              storage.asyncAfter(.seconds(1), workItem)
-            } else {
+            guard state.workItem == nil else {
               state.value = value
               state.continuations.append(continuation)
+              return nil
             }
+            try save(data: data, url: url, modificationDates: &state.modificationDates)
+            continuation.resume()
+            let workItem = DispatchWorkItem { [weak self] in
+              guard let self else { return }
+              self.state.withValue { state in
+                defer {
+                  state.value = nil
+                  state.workItem = nil
+                }
+                guard
+                  let value = state.value,
+                  let data = try? self.encode(value)
+                else { return }
+                let result = Result {
+                  try self.save(
+                    data: data,
+                    url: self.url,
+                    modificationDates: &state.modificationDates
+                  )
+                }
+                for continuation in state.continuations {
+                  continuation.resume(with: result)
+                }
+                state.continuations.removeAll()
+              }
+            }
+            state.workItem = workItem
+            return workItem
 
           case .userInitiated:
             state.cancelWorkItem()
             try storage.save(data, url)
             continuation.resume()
+            return nil
           }
+        }
+        if let workItem {
+          storage.asyncAfter(.seconds(1), workItem)
         }
       } catch {
         continuation.resume(throwing: error)

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -210,17 +210,12 @@
 
     public func save(_ value: Value, context: SaveContext, continuation: SaveContinuation) {
       do {
-        // NB: The work item is scheduled _outside_ of the 'state' lock below. Were it scheduled
-        //     inside, an immediate scheduler (as used by the in-memory test storage) would run it
-        //     re-entrantly while 'state.withValue' still holds a copy of the state. The outer
-        //     scope's write-back would then clobber the 'state.workItem = nil' performed by the
-        //     re-entrant work item, permanently pinning the key in its debounced branch so that
-        //     every subsequent '.didSet' save buffers without ever persisting.
-        let workItem = try state.withValue { state -> DispatchWorkItem? in
+        let workItem: DispatchWorkItem? = try state.withValue { state in
           let data = try encode(value)
           switch context {
           case .didSet:
-            guard state.workItem == nil else {
+            guard state.workItem == nil
+            else {
               state.value = value
               state.continuations.append(continuation)
               return nil

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -99,6 +99,31 @@
       }
     }
 
+    @Test func immediateSchedulerPersistsConsecutiveWrites() throws {
+      // Regression: under the immediate scheduler used by the in-memory test
+      // storage, consecutive '.didSet' writes must each persist. The debounce
+      // work item used to be scheduled while the 'state' lock was held; the
+      // immediate scheduler ran it re-entrantly, and the lock's copy-on-write
+      // write-back clobbered the work item's 'state.workItem = nil', wedging the
+      // key so that every write after the first was buffered but never saved. A
+      // short-lived '@Shared' (recreated across 'await' points, as in a
+      // dependency-client live value) would then reload a stale value.
+      try withDependencies {
+        $0.defaultFileStorage = .inMemory(fileSystem: fileSystem, scheduler: .immediate)
+      } operation: {
+        @Shared(.fileStorage(.fileURL)) var users = [User]()
+
+        $users.withLock { $0.append(.blob) }
+        try expectNoDifference(fileSystem.value.users(for: .fileURL), [.blob])
+
+        $users.withLock { $0.append(.blobJr) }
+        try expectNoDifference(fileSystem.value.users(for: .fileURL), [.blob, .blobJr])
+
+        $users.withLock { $0.append(.blobSr) }
+        try expectNoDifference(fileSystem.value.users(for: .fileURL), [.blob, .blobJr, .blobSr])
+      }
+    }
+
     @Test func multipleFiles() throws {
       try withDependencies {
         $0.defaultFileStorage = .inMemory(fileSystem: fileSystem)

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -95,29 +95,13 @@
       }
     }
 
-    @Test func immediateSchedulerPersistsConsecutiveWrites() throws {
-      // Regression: under the immediate scheduler used by the in-memory test
-      // storage, consecutive '.didSet' writes must each persist. The debounce
-      // work item used to be scheduled while the 'state' lock was held; the
-      // immediate scheduler ran it re-entrantly, and the lock's copy-on-write
-      // write-back clobbered the work item's 'state.workItem = nil', wedging the
-      // key so that every write after the first was buffered but never saved. A
-      // short-lived '@Shared' (recreated across 'await' points, as in a
-      // dependency-client live value) would then reload a stale value.
-      try withDependencies {
-        $0.defaultFileStorage = .inMemory(fileSystem: fileSystem, scheduler: .immediate)
-      } operation: {
-        @Shared(.fileStorage(.fileURL)) var users = [User]()
-
-        $users.withLock { $0.append(.blob) }
-        try expectNoDifference(fileSystem.value.users(for: .fileURL), [.blob])
-
-        $users.withLock { $0.append(.blobJr) }
-        try expectNoDifference(fileSystem.value.users(for: .fileURL), [.blob, .blobJr])
-
-        $users.withLock { $0.append(.blobSr) }
-        try expectNoDifference(fileSystem.value.users(for: .fileURL), [.blob, .blobJr, .blobSr])
-      }
+    @Test func `consecutive writes are persisted and can be loaded`() async throws {
+      @Shared(.fileStorage(.fileURL)) var items = [Int]()
+      $items.withLock { $0.append(1) }
+      $items.withLock { $0.append(2) }
+      #expect(items == [1, 2])
+      try await $items.load()
+      #expect(items == [1, 2])
     }
 
     @Test func multipleFiles() throws {


### PR DESCRIPTION
### Summary

`FileStorageKey`'s `.didSet` debounce can get permanently stuck so that **every save after the first is buffered but never persisted** — whenever the backing storage uses an *immediate* scheduler. That's the default under test, where `defaultFileStorage` resolves to `.inMemory` (`scheduler: .immediate`).

A long-lived `@Shared` masks this, since its in-memory value stays correct. But a short-lived `@Shared` — e.g. one declared *inside* a dependency-client closure and recreated across `await` points — deinits between uses, discards the buffered write, and the next reference reloads a **stale** value from storage. Under parallel Swift Testing this looks like cross-`@Test` `@Shared` "bleed", but per-test isolation is actually intact; the write is dropped *within* a single test.

### Root cause

`save(_:context:continuation:)` arms the debounce work item and schedules it **while still inside `state.withValue { … }`**:

```swift
try state.withValue { state in
  …
  state.workItem = workItem
  storage.asyncAfter(.seconds(1), workItem)   // scheduled inside the lock
}
```

With `.immediate`, `asyncAfter` runs the work item **synchronously and re-entrantly**. Because `LockIsolated.withValue` is copy-and-write-back…

```swift
var value = self._value
defer { self._value = value }   // restores the outer copy on exit
return try operation(&value)
```

…the re-entrant work item's `state.workItem = nil` is **clobbered** by the outer scope's write-back. `state.workItem` then stays non-nil forever (the one-shot work item has already run), so every later `.didSet` save takes the buffering `else` branch and nothing is ever written.

Production (`.fileSystem` → `DispatchQueue.main`) is unaffected: there the work item is genuinely deferred and runs *outside* the lock.

### Fix

Return the work item from `state.withValue` and call `storage.asyncAfter` **after the lock is released**, so it can't run re-entrantly under the lock. Deferred behavior is unchanged; the immediate scheduler now persists every write.

### Tests

Adds `immediateSchedulerPersistsConsecutiveWrites`: two consecutive `.didSet` writes under `.immediate` must both persist. It fails on `main` and passes with the fix. The existing `throttle` / `noThrottling` debounce tests are unchanged.

### Reproduction

The bug reproduces **deterministically** with two consecutive writes — no concurrency required:

```swift
@Test func consecutiveWritesArePersisted() async throws {
    @Shared(.fileStorage(.store)) var items = [Int]()

    $items.withLock { $0.append(1) }
    $items.withLock { $0.append(2) }

    try await $items.load()   // reload from storage

    #expect(items == [1, 2])  // ❌ 2.8.0: items == [1]
}
```

Standalone repro repo (deterministic test; `main` reproduces, the `with-fix` branch points at this fix and passes), with full trace and root-cause analysis: https://github.com/mAu888/swift-sharing-testing-issue

Its CI shows the contrast directly:

- ❌ Bug reproduced on `main` (released 2.8.0): https://github.com/mAu888/swift-sharing-testing-issue/actions/runs/26781467352
- ✅ Passing against this fix (`with-fix` branch): https://github.com/mAu888/swift-sharing-testing-issue/actions/runs/26781476410

Possibly related: #108.
