### PR TITLE
Remove dependence on CombineSchedulers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f43722d8504f193293b5ffc0a080dc7fe33ccb5fad81e44613ef664746cadb14",
+  "originHash" : "d817beac098f7d0dced441d64f76e647dbb78c907389a3ab6945021216175b2d",
   "pins" : [
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9fa31f4403da54855f1e2aeaeff478f4f0e40b13",
-        "version" : "1.0.2"
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "b9b24b69e2adda099a1fa381cda1eeec272d5b53",
-        "version" : "1.0.5"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "163409ef7dae9d960b87f34b51587b6609a76c1f",
-        "version" : "1.3.0"
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
+        "revision" : "b9b59eb58c946236d6f16305c576ad194c36444e",
+        "version" : "1.6.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
-        "version" : "1.9.2"
+        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
+        "version" : "1.12.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
-        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
-        "version" : "1.4.3"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
-        "version" : "1.1.0"
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "f4f57cac7d273cddf0161293d47adbb5a6ba3aed",
-        "version" : "2.0.0"
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     },
     {
@@ -105,10 +105,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "23e3442166b5122f73f9e3e622cd1e4bafeab3b7",
-        "version" : "1.6.0"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,6 @@ let package = Package(
       dependencies: [
         "Sharing1",
         "Sharing2",
-        .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "Dependencies", package: "swift-dependencies"),
@@ -48,6 +47,7 @@ let package = Package(
       name: "SharingTests",
       dependencies: [
         "Sharing",
+        .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "DependenciesTestSupport", package: "swift-dependencies"),
       ],
       exclude: ["Sharing.xctestplan"]

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -17,7 +17,6 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.5.1"),
@@ -32,7 +31,6 @@ let package = Package(
       dependencies: [
         "Sharing1",
         "Sharing2",
-        .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "Dependencies", package: "swift-dependencies"),

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -1,6 +1,5 @@
 #if canImport(AppKit) || canImport(UIKit) || canImport(WatchKit)
   import Combine
-  import CombineSchedulers
   import ConcurrencyExtras
   public import Dependencies
   @preconcurrency import Dispatch
@@ -388,14 +387,15 @@
 
     @_spi(Internals) public static func inMemory(
       fileSystem: LockIsolated<[URL: Data]>,
-      scheduler: AnySchedulerOf<DispatchQueue> = .immediate
+      async: @escaping @Sendable (DispatchWorkItem) -> Void = { $0.perform() },
+      asyncAfter: @escaping @Sendable (DispatchTimeInterval, DispatchWorkItem) -> Void = {
+        _, workItem in workItem.perform()
+      }
     ) -> Self {
       return Self(
         id: AnyHashableSendable(ObjectIdentifier(fileSystem)),
-        async: { scheduler.schedule($0.perform) },
-        asyncAfter: {
-          scheduler.schedule(after: scheduler.now.advanced(by: .init($0)), $1.perform)
-        },
+        async: async,
+        asyncAfter: asyncAfter,
         attributesOfItemAtPath: { _ in [:] },
         createDirectory: { _, _ in },
         fileExists: { fileSystem.keys.contains($0) },

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -1,5 +1,6 @@
 #if canImport(AppKit) || canImport(UIKit) || canImport(WatchKit)
   import Combine
+  import CombineSchedulers
   import CustomDump
   import Dependencies
   import DependenciesTestSupport
@@ -13,7 +14,7 @@
 
     @Test func basics() throws {
       try withDependencies {
-        $0.defaultFileStorage = .inMemory(fileSystem: fileSystem, scheduler: .immediate)
+        $0.defaultFileStorage = .inMemory(fileSystem: fileSystem)
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         #expect($users.loadError == nil)
@@ -27,7 +28,7 @@
 
     @Test func customEncodeDecode() {
       withDependencies {
-        $0.defaultFileStorage = .inMemory(fileSystem: fileSystem, scheduler: .immediate)
+        $0.defaultFileStorage = .inMemory(fileSystem: fileSystem)
       } operation: {
         @Shared(.utf8String) var string = ""
         #expect($string.loadError == nil)
@@ -44,10 +45,7 @@
 
     @Test func throttle() throws {
       try withDependencies {
-        $0.defaultFileStorage = .inMemory(
-          fileSystem: fileSystem,
-          scheduler: testScheduler.eraseToAnyScheduler()
-        )
+        $0.defaultFileStorage = .inMemory(fileSystem: fileSystem, scheduler: testScheduler)
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         try expectNoDifference(fileSystem.value.users(for: .fileURL), nil)
@@ -82,10 +80,7 @@
 
     @Test func noThrottling() throws {
       try withDependencies {
-        $0.defaultFileStorage = .inMemory(
-          fileSystem: fileSystem,
-          scheduler: testScheduler.eraseToAnyScheduler()
-        )
+        $0.defaultFileStorage = .inMemory(fileSystem: fileSystem, scheduler: testScheduler)
       } operation: {
         @Shared(.fileStorage(.fileURL)) var users = [User]()
         try expectNoDifference(fileSystem.value.users(for: .fileURL), nil)
@@ -476,6 +471,21 @@
         #expect(count == 999)
         #expect(try String(decoding: Data(contentsOf: .fileURL), as: UTF8.self) == "999")
       }
+    }
+  }
+
+  extension FileStorage {
+    fileprivate static func inMemory<S: Scheduler & Sendable>(
+      fileSystem: LockIsolated<[URL: Data]>,
+      scheduler: S
+    ) -> Self where S.SchedulerTimeType == DispatchQueue.SchedulerTimeType {
+      .inMemory(
+        fileSystem: fileSystem,
+        async: { scheduler.schedule($0.perform) },
+        asyncAfter: {
+          scheduler.schedule(after: scheduler.now.advanced(by: .init($0)), $1.perform)
+        }
+      )
     }
   }
 


### PR DESCRIPTION
Sharing currently depends on CombineSchedulers to control the scheduling of the file storage persistence strategy. This is only necessary for tests, so lets weaken the dependency by moving it to the test target.