### PR TITLE
Fix build on Swift 6.4 (Xcode 27)

### DIFF
--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -64,7 +64,7 @@ extension Shared {
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading and saving the shared reference's value from some external source.
-  public init(_ key: (some SharedKey<Value>).Default) {
+  public init<Key: SharedKey<Value>>(_ key: Key.Default) {
     self.init(wrappedValue: key.initialValue, key.base)
   }
 
@@ -75,9 +75,9 @@ extension Shared {
   ///     shared key.
   ///   - key: A shared key associated with the shared reference. It is responsible for loading
   ///     and saving the shared reference's value from some external source.
-  public init(
+  public init<Key: SharedKey<Value>>(
     wrappedValue: @autoclosure () -> Value,
-    _ key: (some SharedKey<Value>).Default
+    _ key: Key.Default
   ) {
     self.init(wrappedValue: wrappedValue(), key.base)
   }
@@ -125,10 +125,15 @@ extension Shared {
     if let loadError { throw loadError }
   }
 
-  @available(*, unavailable, message: "Assign a default value")
-  public init(_ key: some SharedKey<Value>) {
-    fatalError()
-  }
+  // NB: Diagnostic-only init omitted on Swift 6.4+ to avoid a SILGen crash
+  //     (emitMemberInitializers) for non-delegating generic inits over a type storing `@State`.
+  //     See: https://github.com/swiftlang/swift/issues/89808
+  #if compiler(<6.4)
+    @available(*, unavailable, message: "Assign a default value")
+    public init(_ key: some SharedKey<Value>) {
+      fatalError()
+    }
+  #endif
 
   private init(
     rethrowing value: @autoclosure () throws -> Value, _ key: some SharedKey<Value>,

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -115,13 +115,13 @@ extension SharedReader {
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
-  public init(_ key: (some SharedReaderKey<Value>).Default) {
+  public init<Key: SharedReaderKey<Value>>(_ key: Key.Default) {
     self.init(wrappedValue: key.initialValue, key.base)
   }
 
   @_disfavoredOverload
   @_documentation(visibility: private)
-  public init(_ key: (some SharedKey<Value>).Default) {
+  public init<Key: SharedKey<Value>>(_ key: Key.Default) {
     self.init(key)
   }
 
@@ -133,17 +133,17 @@ extension SharedReader {
   ///     shared key.
   ///   - key: A shared key associated with the shared reference. It is responsible for loading the
   ///     shared reference's value from some external source.
-  public init(
+  public init<Key: SharedReaderKey<Value>>(
     wrappedValue: @autoclosure () -> Value,
-    _ key: (some SharedReaderKey<Value>).Default
+    _ key: Key.Default
   ) {
     self.init(wrappedValue: wrappedValue(), key.base)
   }
 
   @_documentation(visibility: private)
-  public init(
+  public init<Key: SharedKey<Value>>(
     wrappedValue: @autoclosure () -> Value,
-    _ key: (some SharedKey<Value>).Default
+    _ key: Key.Default
   ) {
     self.init(wrappedValue: wrappedValue(), key.base)
   }
@@ -203,17 +203,23 @@ extension SharedReader {
     try await self.init(require: key)
   }
 
-  @available(*, unavailable, message: "Assign a default value")
-  public init(_ key: some SharedReaderKey<Value>) {
-    fatalError()
-  }
+  // NB: These diagnostic-only initializers are non-delegating generic inits over a type that
+  //     stores an `@State` property, which crashes SILGen on Swift 6.4. They exist purely to
+  //     surface a friendlier "Assign a default value" error, so we omit them on 6.4+.
+  //     See: https://github.com/swiftlang/swift/issues/89808 (emitMemberInitializers crash)
+  #if compiler(<6.4)
+    @available(*, unavailable, message: "Assign a default value")
+    public init(_ key: some SharedReaderKey<Value>) {
+      fatalError()
+    }
 
-  @_disfavoredOverload
-  @_documentation(visibility: private)
-  @available(*, unavailable, message: "Assign a default value")
-  public init(_ key: some SharedKey<Value>) {
-    fatalError()
-  }
+    @_disfavoredOverload
+    @_documentation(visibility: private)
+    @available(*, unavailable, message: "Assign a default value")
+    public init(_ key: some SharedKey<Value>) {
+      fatalError()
+    }
+  #endif
 
   private init(
     rethrowing value: @autoclosure () throws -> Value, _ key: some SharedReaderKey<Value>,

--- a/Sources/Sharing/SwiftUIStateSharing.swift
+++ b/Sources/Sharing/SwiftUIStateSharing.swift
@@ -83,15 +83,15 @@
       }
 
       @_documentation(visibility: private)
-      public init(_ key: (some SharedKey<Value>).Default) {
+      public init<Key: SharedKey<Value>>(_ key: Key.Default) {
         shared = Sharing.Shared(wrappedValue: key.initialValue, key)
       }
 
       @_disfavoredOverload
       @_documentation(visibility: private)
-      public init(
+      public init<Key: SharedKey<Value>>(
         wrappedValue: @autoclosure () -> Value,
-        _ key: (some SharedKey<Value>).Default
+        _ key: Key.Default
       ) {
         shared = Sharing.Shared(wrappedValue: wrappedValue(), key)
       }
@@ -204,29 +204,29 @@
       }
 
       @_documentation(visibility: private)
-      public init(_ key: (some SharedReaderKey<Value>).Default) {
+      public init<Key: SharedReaderKey<Value>>(_ key: Key.Default) {
         shared = Sharing.SharedReader(key)
       }
 
       @_disfavoredOverload
       @_documentation(visibility: private)
-      public init(_ key: (some SharedKey<Value>).Default) {
+      public init<Key: SharedKey<Value>>(_ key: Key.Default) {
         shared = Sharing.SharedReader(key)
       }
 
       @_disfavoredOverload
-      public init(
+      public init<Key: SharedReaderKey<Value>>(
         wrappedValue: @autoclosure () -> Value,
-        _ key: (some SharedReaderKey<Value>).Default
+        _ key: Key.Default
       ) {
         shared = Sharing.SharedReader(wrappedValue: wrappedValue(), key)
       }
 
       @_disfavoredOverload
       @_documentation(visibility: private)
-      public init(
+      public init<Key: SharedKey<Value>>(
         wrappedValue: @autoclosure () -> Value,
-        _ key: (some SharedKey<Value>).Default
+        _ key: Key.Default
       ) {
         shared = Sharing.SharedReader(wrappedValue: wrappedValue(), key)
       }


### PR DESCRIPTION
## Summary

`swift-sharing` does not compile with **Swift 6.4 (Xcode 27)**. There are two independent issues; this PR fixes both and keeps building on Swift 6.2.

### 1. `(some P<Value>).Default` is rejected by the Swift 6.4 type checker

Twelve initializers across `SharedKey.swift`, `SharedReaderKey.swift` and `SwiftUIStateSharing.swift` take a parameter typed `(some SharedKey<Value>).Default` / `(some SharedReaderKey<Value>).Default`. Accessing a member type on an opaque parameter type is no longer accepted:

```
error: cannot access member type 'Default' on opaque type 'some SharedKey<Value>'
```

Fix: replace the opaque-parameter sugar with an explicit generic parameter, which is semantically identical (`some P` *is* an implicit generic parameter) and accepted by both Swift 6.2 and 6.4:

```diff
-public init(_ key: (some SharedKey<Value>).Default) {
+public init<Key: SharedKey<Value>>(_ key: Key.Default) {
```

### 2. SILGen crash on the `@available(*, unavailable)` diagnostic initializers

Once (1) type-checks, the compiler **segfaults** during SIL generation:

```
swift::Lowering::SILGenFunction::emitMemberInitializers(...)
While emitting SIL for 'init(_:)' (at SharedReaderKey.swift:207)
init<A where A == A1.Value, A1: SharedReaderKey>(A1) -> SharedReader<A>
```

The crash is triggered by the `@available(*, unavailable, message: "Assign a default value")` initializers `init(_ key: some SharedReaderKey<Value>)` / `init(_ key: some SharedKey<Value>)` on `Shared` / `SharedReader`. These are **non-delegating generic initializers** over a type that stores an `@State` property with a default value (`@State private var generation = 0`), and Swift 6.4 crashes substituting the member initializer in the generic context. Removing **only** these initializers lets the whole package build.

Because they exist purely to surface a friendlier error and are never executed (`fatalError()`), they are gated behind `#if compiler(<6.4)` until the underlying compiler bug is fixed. A separate report has been filed against the Swift compiler: https://github.com/swiftlang/swift/issues/89808 (a SILGen crash on otherwise valid code).

## Verification

- ✅ `swift build` on Swift 6.4 (Xcode 27 beta)
- ✅ `swift test` on Swift 6.4 (122 tests; only pre-existing environment-dependent failures around `/tmp` URL resolution and file-storage timing, unrelated to these type-level changes)
- ✅ `swift build` on Swift 6.2.4 (Xcode 26.3) — backward compatible
