### PR TITLE
Add more explicit `import`s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,43 +18,25 @@ jobs:
     name: macOS
     strategy:
       matrix:
-        xcode: ['16.4']
+        xcode: ['26.5']
         config: ['debug', 'release']
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run ${{ matrix.config }} tests
-        run: swift test -c ${{ matrix.config }}
+        run: swift test -c ${{ matrix.config }} -Xswiftc -D -Xswiftc EXCLUDE_EXPORTS
 
   linux:
     name: Linux
     strategy:
       matrix:
         swift:
-          - '6.0'
+          - '6.3'
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build
         run: swift build
-
-  # wasm:
-  #   name: Wasm
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: bytecodealliance/actions/wasmtime/setup@v1
-  #     - name: Install Swift and Swift SDK for WebAssembly
-  #       run: |
-  #         PREFIX=/opt/swift
-  #         set -ex
-  #         curl -f -o /tmp/swift.tar.gz "https://download.swift.org/swift-6.0.3-release/ubuntu2204/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE-ubuntu22.04.tar.gz"
-  #         sudo mkdir -p $PREFIX; sudo tar -xzf /tmp/swift.tar.gz -C $PREFIX --strip-component 1
-  #         $PREFIX/usr/bin/swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0.3-RELEASE/swift-wasm-6.0.3-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 31d3585b06dd92de390bacc18527801480163188cd7473f492956b5e213a8618
-  #         echo "$PREFIX/usr/bin" >> $GITHUB_PATH
-  #
-  #     - name: Build
-  #       run: swift build --swift-sdk wasm32-unknown-wasi -Xlinker -z -Xlinker stack-size=$((1024 * 1024))

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d817beac098f7d0dced441d64f76e647dbb78c907389a3ab6945021216175b2d",
+  "originHash" : "1f376db5c1affb48943d5edba2339f1f6b0041ba56c7051c07e8741277056d72",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
-        "version" : "1.0.6"
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
-        "version" : "1.5.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
-        "version" : "1.12.0"
+        "revision" : "f80552807ec92f72fe3fe4543d71879182b0bfd5",
+        "version" : "1.13.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
-        "version" : "603.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
       }
     }
   ],

--- a/Sources/Sharing/Internal/Reference.swift
+++ b/Sources/Sharing/Internal/Reference.swift
@@ -1,6 +1,7 @@
 import Dependencies
 import Foundation
 import IdentifiedCollections
+import IssueReporting
 public import PerceptionCore
 
 #if canImport(Combine)

--- a/Sources/Sharing/SharedKeys/AppStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/AppStorageKey.swift
@@ -1,6 +1,8 @@
 #if canImport(AppKit) || canImport(UIKit) || canImport(WatchKit)
+  import ConcurrencyExtras
   public import Dependencies
   @preconcurrency public import Foundation
+  import IssueReporting
 
   #if canImport(AppKit)
     import AppKit
@@ -60,7 +62,7 @@
     where Self == AppStorageKey<String> {
       AppStorageKey(key, store: store)
     }
-    
+
     /// Creates a shared key that can read and write to a string array user default.
     ///
     /// - Parameters:
@@ -72,7 +74,7 @@
     where Self == AppStorageKey<[String]> {
       AppStorageKey(key, store: store)
     }
-    
+
     /// Creates a shared key that can read and write to a URL user default.
     ///
     /// - Parameters:
@@ -108,7 +110,7 @@
     where Self == AppStorageKey<Date> {
       AppStorageKey(key, store: store)
     }
-    
+
     /// Creates a shared key that can read and write a codable value to user defaults.
     ///
     /// - Parameters:
@@ -118,7 +120,8 @@
     /// - Returns: A user defaults shared key.
     @_disfavoredOverload
     public static func appStorage<Value: Codable>(
-      _ key: String, store: UserDefaults? = nil
+      _ key: String,
+      store: UserDefaults? = nil
     ) -> Self
     where Self == AppStorageKey<Value> {
       AppStorageKey(key, store: store)
@@ -133,7 +136,8 @@
     ///     default store from dependencies.
     /// - Returns: A user defaults shared key.
     public static func appStorage<Value: RawRepresentable<Int>>(
-      _ key: String, store: UserDefaults? = nil
+      _ key: String,
+      store: UserDefaults? = nil
     ) -> Self
     where Self == AppStorageKey<Value> {
       AppStorageKey(key, store: store)
@@ -148,7 +152,8 @@
     ///     default store from dependencies.
     /// - Returns: A user defaults shared key.
     public static func appStorage<Value: RawRepresentable<String>>(
-      _ key: String, store: UserDefaults? = nil
+      _ key: String,
+      store: UserDefaults? = nil
     ) -> Self
     where Self == AppStorageKey<Value> {
       AppStorageKey(key, store: store)
@@ -201,7 +206,7 @@
     where Self == AppStorageKey<String?> {
       AppStorageKey(key, store: store)
     }
-    
+
     /// Creates a shared key that can read and write to an optional string array user default.
     ///
     /// - Parameters:
@@ -213,7 +218,7 @@
     where Self == AppStorageKey<[String]?> {
       AppStorageKey(key, store: store)
     }
-    
+
     /// Creates a shared key that can read and write to an optional URL user default.
     ///
     /// - Parameters:
@@ -249,7 +254,7 @@
     where Self == AppStorageKey<Date?> {
       AppStorageKey(key, store: store)
     }
-    
+
     /// Creates a shared key that can read and write a codable value to user defaults.
     ///
     /// - Parameters:
@@ -259,7 +264,8 @@
     /// - Returns: A user defaults shared key.
     @_disfavoredOverload
     public static func appStorage<Value: Codable>(
-      _ key: String, store: UserDefaults? = nil
+      _ key: String,
+      store: UserDefaults? = nil
     ) -> Self
     where Self == AppStorageKey<Value?> {
       AppStorageKey(key, store: store)
@@ -274,7 +280,8 @@
     ///     default store from dependencies.
     /// - Returns: A user defaults shared key.
     public static func appStorage<Value: RawRepresentable>(
-      _ key: String, store: UserDefaults? = nil
+      _ key: String,
+      store: UserDefaults? = nil
     ) -> Self
     where Value.RawValue == Int, Self == AppStorageKey<Value?> {
       AppStorageKey(key, store: store)
@@ -289,7 +296,8 @@
     ///     default store from dependencies.
     /// - Returns: A user defaults shared key.
     public static func appStorage<Value: RawRepresentable>(
-      _ key: String, store: UserDefaults? = nil
+      _ key: String,
+      store: UserDefaults? = nil
     ) -> Self
     where Value.RawValue == String, Self == AppStorageKey<Value?> {
       AppStorageKey(key, store: store)
@@ -359,11 +367,11 @@
     fileprivate init(_ key: String, store: UserDefaults?) where Value == String {
       self.init(lookup: CastableLookup(), key: key, store: store)
     }
-    
+
     fileprivate init(_ key: String, store: UserDefaults?) where Value == [String] {
       self.init(lookup: CastableLookup(), key: key, store: store)
     }
-    
+
     fileprivate init(_ key: String, store: UserDefaults?) where Value == URL {
       self.init(lookup: URLLookup(), key: key, store: store)
     }
@@ -403,11 +411,11 @@
     fileprivate init(_ key: String, store: UserDefaults?) where Value == String? {
       self.init(lookup: OptionalLookup(base: CastableLookup()), key: key, store: store)
     }
-    
+
     fileprivate init(_ key: String, store: UserDefaults?) where Value == [String]? {
       self.init(lookup: OptionalLookup(base: CastableLookup()), key: key, store: store)
     }
-    
+
     fileprivate init(_ key: String, store: UserDefaults?) where Value == URL? {
       self.init(lookup: OptionalLookup(base: URLLookup()), key: key, store: store)
     }
@@ -419,7 +427,7 @@
     fileprivate init(_ key: String, store: UserDefaults?) where Value == Date? {
       self.init(lookup: OptionalLookup(base: CastableLookup()), key: key, store: store)
     }
-    
+
     fileprivate init<C: Codable>(_ key: String, store: UserDefaults?)
     where Value == C? {
       self.init(
@@ -452,7 +460,8 @@
     }
 
     public func subscribe(
-      context: LoadContext<Value>, subscriber: SharedSubscriber<Value>
+      context: LoadContext<Value>,
+      subscriber: SharedSubscriber<Value>
     ) -> SharedSubscription {
       let removeObserver: @Sendable () -> Void
       let keyContainsPeriod = key.contains(".")
@@ -732,7 +741,9 @@
   where Value.RawValue == Base.Value {
     let base: Base
     func loadValue(
-      from store: UserDefaults, at key: String, default defaultValue: Value?
+      from store: UserDefaults,
+      at key: String,
+      default defaultValue: Value?
     ) -> Value? {
       base.loadValue(from: store, at: key, default: defaultValue?.rawValue)
         .flatMap(Value.init(rawValue:))
@@ -745,7 +756,9 @@
   private struct OptionalLookup<Base: Lookup>: Lookup {
     let base: Base
     func loadValue(
-      from store: UserDefaults, at key: String, default defaultValue: Base.Value??
+      from store: UserDefaults,
+      at key: String,
+      default defaultValue: Base.Value??
     ) -> Base.Value?? {
       base.loadValue(from: store, at: key, default: defaultValue ?? nil)
         .flatMap(Optional.some)

--- a/Sources/Sharing/SharedKeys/FileStorageKey.swift
+++ b/Sources/Sharing/SharedKeys/FileStorageKey.swift
@@ -1,6 +1,6 @@
 #if canImport(AppKit) || canImport(UIKit) || canImport(WatchKit)
   import Combine
-  import ConcurrencyExtras
+  public import ConcurrencyExtras
   public import Dependencies
   @preconcurrency import Dispatch
 
@@ -120,7 +120,8 @@
     }
 
     public func subscribe(
-      context _: LoadContext<Value>, subscriber: SharedSubscriber<Value>
+      context _: LoadContext<Value>,
+      subscriber: SharedSubscriber<Value>
     ) -> SharedSubscription {
       let cancellable = Mutex<SharedSubscription?>(nil)
       @Sendable func setUpSources() {
@@ -389,7 +390,8 @@
       fileSystem: LockIsolated<[URL: Data]>,
       async: @escaping @Sendable (DispatchWorkItem) -> Void = { $0.perform() },
       asyncAfter: @escaping @Sendable (DispatchTimeInterval, DispatchWorkItem) -> Void = {
-        _, workItem in workItem.perform()
+        _,
+        workItem in workItem.perform()
       }
     ) -> Self {
       return Self(

--- a/Tests/SharingTests/AppStorageTests.swift
+++ b/Tests/SharingTests/AppStorageTests.swift
@@ -46,14 +46,14 @@
       @Shared(.appStorage("url")) var url = URL(fileURLWithPath: "/dev")
       #expect(store.url(forKey: "url") == URL(fileURLWithPath: "/dev"))
       store.set(URL(fileURLWithPath: "/tmp"), forKey: "url")
-      #expect(url == URL(fileURLWithPath: "/tmp"))
+      #expect(url == URL(fileURLWithPath: "/tmp/"))
     }
 
     @Test func optionalURL() {
       @Shared(.appStorage("url")) var url: URL? = URL(fileURLWithPath: "/dev")
       #expect(store.url(forKey: "url") == URL(fileURLWithPath: "/dev"))
       store.set(URL(fileURLWithPath: "/tmp"), forKey: "url")
-      #expect(url == URL(fileURLWithPath: "/tmp"))
+      #expect(url == URL(fileURLWithPath: "/tmp/"))
       $url.withLock { $0 = nil }
       #expect(url == nil)
     }

--- a/Tests/SharingTests/FileStorageTests.swift
+++ b/Tests/SharingTests/FileStorageTests.swift
@@ -1,6 +1,7 @@
 #if canImport(AppKit) || canImport(UIKit) || canImport(WatchKit)
   import Combine
   import CombineSchedulers
+  import ConcurrencyExtras
   import CustomDump
   import Dependencies
   import DependenciesTestSupport


### PR DESCRIPTION
Tests fail when using `EXCLUDE_EXPORTS` downstream, so we should adopt it in our CI here, as well.