### PR TITLE
Integrate CasePaths trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,14 @@ jobs:
       matrix:
         xcode: ['26.5']
         config: ['debug', 'release']
+        traits: ['', 'CasePaths']
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run ${{ matrix.config }} tests
-        run: swift test -c ${{ matrix.config }} -Xswiftc -D -Xswiftc EXCLUDE_EXPORTS
+        run: swift test -c ${{ matrix.config }} -Xswiftc -D -Xswiftc EXCLUDE_EXPORTS ${{ matrix.traits != '' && format('--traits {0}', matrix.traits) || '' }}
 
   linux:
     name: Linux
@@ -34,9 +35,10 @@ jobs:
       matrix:
         swift:
           - '6.3'
+        traits: ['', 'CasePaths']
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}
     steps:
       - uses: actions/checkout@v5
       - name: Build
-        run: swift build
+        run: swift build ${{ matrix.traits != '' && format('--traits {0}', matrix.traits) || '' }}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9489c314295f122bbec4e61194cd1d4956fa32e0e6ecc72e35927745a344326f",
+  "originHash" : "2d35c0c3e737b76f5d253977c3cab7b3210ea33058a79bc2ee0aa80767457fbc",
   "pins" : [
     {
       "identity" : "combine-schedulers",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1f376db5c1affb48943d5edba2339f1f6b0041ba56c7051c07e8741277056d72",
+  "originHash" : "9489c314295f122bbec4e61194cd1d4956fa32e0e6ecc72e35927745a344326f",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
+        "version" : "1.7.3"
       }
     },
     {
@@ -96,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
-        "version" : "603.0.2"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -48,9 +48,9 @@ let package = Package(
         .product(
           name: "CasePaths",
           package: "swift-case-paths",
-//          condition: .when(
-//            traits: ["CasePaths"]
-//          )
+          condition: .when(
+            traits: ["CasePaths"]
+          )
         )
       ],
       resources: [
@@ -63,6 +63,13 @@ let package = Package(
         "Sharing",
         .product(name: "CombineSchedulers", package: "combine-schedulers"),
         .product(name: "DependenciesTestSupport", package: "swift-dependencies"),
+        .product(
+          name: "CasePaths",
+          package: "swift-case-paths",
+          condition: .when(
+            traits: ["CasePaths"]
+          )
+        ),
       ],
       exclude: ["Sharing.xctestplan"]
     ),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -16,15 +16,8 @@ let package = Package(
       targets: ["Sharing"]
     )
   ],
-  traits: [
-    .trait(
-      name: "CasePaths",
-      description: "Adds support for deriving enum cases into a Shared reference"
-    )
-  ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.7.3"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.5.1"),
@@ -45,13 +38,6 @@ let package = Package(
         .product(name: "IdentifiedCollections", package: "swift-identified-collections"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(name: "PerceptionCore", package: "swift-perception"),
-        .product(
-          name: "CasePaths",
-          package: "swift-case-paths",
-//          condition: .when(
-//            traits: ["CasePaths"]
-//          )
-        )
       ],
       resources: [
         .process("PrivacyInfo.xcprivacy")

--- a/Sources/Sharing/Traits/CasePaths.swift
+++ b/Sources/Sharing/Traits/CasePaths.swift
@@ -1,0 +1,214 @@
+//#if CasePaths
+public import CasePaths
+
+#if canImport(Combine)
+  import Combine
+#endif
+
+extension Shared {
+  @_disfavoredOverload
+  public subscript<Member>(
+    dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member>>
+  ) -> Shared<Member>?
+  where Value: CasePathable {
+    func open(_ reference: some MutableReference<Value>) -> Shared<Member?> {
+      Shared<Member?>(
+        reference: _MutableReferenceEnumToOptionalCase(base: reference, keyPath: keyPath.unsafeSendable())
+      )
+    }
+    return Shared<Member>(open(reference))
+  }
+}
+
+extension SharedReader {
+  @_disfavoredOverload
+  public subscript<Member>(
+    dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member>>
+  ) -> SharedReader<Member>?
+  where Value: CasePathable {
+    func open(_ reference: some Reference<Value>) -> SharedReader<Member?> {
+      SharedReader<Member?>(
+        reference: _ReferenceEnumToOptionalCase(base: reference, keyPath: keyPath.unsafeSendable())
+      )
+    }
+    return SharedReader<Member>(open(reference))
+  }
+}
+
+private final class _ReferenceEnumToOptionalCase<Base: Reference, Case>
+where Base.Value: CasePathable {
+  typealias Value = Case?
+  let base: Base
+  let keyPath: _SendableKeyPath<Base.Value.AllCasePaths, AnyCasePath<Base.Value, Case>>
+  let casePath: AnyCasePath<Base.Value, Case>
+  
+  init(
+    base: Base, keyPath: _SendableKeyPath<Base.Value.AllCasePaths, AnyCasePath<Base.Value, Case>>
+  ) {
+    self.base = base
+    self.keyPath = keyPath
+    self.casePath = Base.Value.allCasePaths[keyPath: keyPath]
+  }
+}
+
+extension _ReferenceEnumToOptionalCase: CustomStringConvertible {
+  var description: String {
+    "\(base.description)[dynamicMember: \(keyPath)]"
+  }
+}
+
+extension _ReferenceEnumToOptionalCase: Reference {
+  var id: ObjectIdentifier {
+    base.id
+  }
+  
+  var isLoading: Bool {
+    base.isLoading
+  }
+  
+  var loadError: (any Error)? {
+    base.loadError
+  }
+  
+  var wrappedValue: Value {
+    casePath.extract(from: base.wrappedValue)
+  }
+  
+  func load() async throws {
+    try await base.load()
+  }
+  
+  func touch() {
+    base.touch()
+  }
+  
+#if canImport(Combine)
+  var publisher: any Publisher<Value, Never> {
+    func open(
+      _ publisher: some Publisher<Base.Value, Never>,
+      extract: @escaping @Sendable (Base.Value) -> Value
+    ) -> any Publisher<Value, Never> {
+      publisher.map(extract)
+    }
+    return open(
+      base.publisher,
+      extract: { [casePath] in
+        casePath.extract(from: $0)
+      }
+    )
+  }
+#endif
+}
+
+private final class _MutableReferenceEnumToOptionalCase<Base: MutableReference, Case>
+where Base.Value: CasePathable {
+  typealias Value = Case?
+  let base: Base
+  let keyPath: _SendableKeyPath<Base.Value.AllCasePaths, AnyCasePath<Base.Value, Case>>
+  let casePath: AnyCasePath<Base.Value, Case>
+  
+  init(
+    base: Base, keyPath: _SendableKeyPath<Base.Value.AllCasePaths, AnyCasePath<Base.Value, Case>>
+  ) {
+    self.base = base
+    self.keyPath = keyPath
+    self.casePath = Base.Value.allCasePaths[keyPath: keyPath]
+  }
+}
+
+extension _MutableReferenceEnumToOptionalCase: CustomStringConvertible {
+  var description: String {
+    "\(base.description)[dynamicMember: \(keyPath)]"
+  }
+}
+
+extension _MutableReferenceEnumToOptionalCase: Reference {
+  var id: ObjectIdentifier {
+    base.id
+  }
+  
+  var isLoading: Bool {
+    base.isLoading
+  }
+  
+  var loadError: (any Error)? {
+    base.loadError
+  }
+  
+  var wrappedValue: Value {
+    casePath.extract(from: base.wrappedValue)
+  }
+  
+  func load() async throws {
+    try await base.load()
+  }
+  
+  func touch() {
+    base.touch()
+  }
+  
+#if canImport(Combine)
+  var publisher: any Publisher<Value, Never> {
+    func open(
+      _ publisher: some Publisher<Base.Value, Never>,
+      extract: @escaping @Sendable (Base.Value) -> Value
+    ) -> any Publisher<Value, Never> {
+      publisher.map(extract)
+    }
+    return open(
+      base.publisher,
+      extract: { [casePath] in
+        casePath.extract(from: $0)
+      }
+    )
+  }
+#endif
+}
+  
+extension _MutableReferenceEnumToOptionalCase: MutableReference {
+  var saveError: (any Error)? {
+    base.saveError
+  }
+  
+  var snapshot: Value? {
+    base.snapshot.flatMap {
+      casePath.extract(from: $0)
+    }
+  }
+  
+  func withLock<R>(_ body: (inout Value) throws -> R) rethrows -> R {
+    try base.withLock { value in
+      var `case` = casePath.extract(from: value)
+      let result = try body(&`case`)
+      if let `case` {
+        value = casePath.embed(`case`)
+      }
+      return result
+    }
+  }
+  func takeSnapshot(
+    _ value: Value,
+    fileID: StaticString,
+    filePath: StaticString,
+    line: UInt,
+    column: UInt
+  ) {
+    guard let value = value.flatMap({ casePath.embed($0) }) else { return }
+    base.takeSnapshot(
+      value,
+      fileID: fileID,
+      filePath: filePath,
+      line: line,
+      column: column
+    )
+  }
+  func save() async throws {
+    try await base.save()
+  }
+  
+  static func == (lhs: _MutableReferenceEnumToOptionalCase, rhs: _MutableReferenceEnumToOptionalCase) -> Bool {
+    lhs.base == rhs.base && lhs.keyPath == rhs.keyPath
+  }
+}
+
+//#endif

--- a/Sources/Sharing/Traits/CasePaths.swift
+++ b/Sources/Sharing/Traits/CasePaths.swift
@@ -1,4 +1,4 @@
-//#if CasePaths
+#if CasePaths
 public import CasePaths
 
 #if canImport(Combine)
@@ -211,4 +211,4 @@ extension _MutableReferenceEnumToOptionalCase: MutableReference {
   }
 }
 
-//#endif
+#endif

--- a/Tests/SharingTests/CasePathsTraitTests.swift
+++ b/Tests/SharingTests/CasePathsTraitTests.swift
@@ -1,0 +1,114 @@
+#if CasePaths
+import CasePaths
+@_spi(SharedChangeTracking) import Sharing
+import Testing
+import PerceptionCore
+
+@Suite struct CasePathsTraitTests {
+  @CasePathable
+  @dynamicMemberLookup
+  enum Route: Equatable {
+    case detail(Int)
+    case settings
+  }
+
+  struct Model: Equatable {
+    var route: Route
+  }
+
+  @Test func readsCaseThroughShared() throws {
+    @Shared(value: Model(route: .detail(42))) var model
+
+    let detailReader: SharedReader<Int>? = $model.route.detail
+    #expect(detailReader?.wrappedValue == 42)
+    
+    let detail: Shared<Int>? = $model.route.detail
+    #expect(detail?.wrappedValue == 42)
+  }
+
+  @Test func writesCaseThroughShared() throws {
+    @Shared(value: Model(route: .detail(42))) var model
+
+    let _detail: Shared<Int>? = $model.route.detail
+    let detail = try #require(_detail)
+    detail.withLock { $0 = 100 }
+
+    #expect(model.route == .detail(100))
+  }
+
+  @Test func returnsNilForNonMatchingCase() {
+    @Shared(value: Model(route: .settings)) var model
+
+    let detail: Shared<Int>? = $model.route.detail
+    #expect(detail == nil)
+  }
+  
+  @Test func sharedReaderReturnsNilForNonMatchingCase() {
+    @Shared(value: Model(route: .settings)) var model
+    let detailReader: SharedReader<Int>? = $model.route.detail
+    #expect(detailReader == nil)
+  }
+  
+  @Test func sharedCaseReflectsExternalMutation() throws {
+    @Shared(value: Model(route: .detail(1))) var model
+    let _detail: Shared<Int>? = $model.route.detail
+    let detail = try #require(_detail)
+    $model.withLock { $0.route = .detail(99) }
+    #expect(detail.wrappedValue == 99)
+  }
+  
+  @Test func sharedReaderCaseReflectsExternalMutation() throws {
+    @Shared(value: Model(route: .detail(1))) var model
+    let _detail: SharedReader<Int>? = $model.route.detail
+    let detail = try #require(_detail)
+    $model.withLock { $0.route = .detail(99) }
+    #expect(detail.wrappedValue == 99)
+  }
+  
+  @Test func writesAreDroppedAfterCaseSwitch() throws {
+    @Shared(value: Model(route: .detail(1))) var model
+    let _detail: Shared<Int>? = $model.route.detail
+    let detail = try #require(_detail)
+    $model.withLock { $0.route = .settings }   // switch away
+    detail.withLock { $0 = 999 }               // should be a no-op
+    #expect(model.route == .settings)
+  }
+  
+  @MainActor
+  @Test func casePathMutationTriggersObservation() async throws {
+    @Shared(value: Model(route: .detail(0))) var model
+    let _detail: Shared<Int>? = $model.route.detail
+    let detail = try #require(_detail)
+    await confirmation { confirm in
+      withObservationTracking {
+        _ = model.route
+      } onChange: {
+        confirm()
+      }
+      detail.withLock { $0 = 1 }
+    }
+  }
+  
+  @Test func tracking() throws {
+    @Shared(value: Route.detail(0)) var model
+    let _detail: Shared<Int>? = $model.detail
+    let detail = try #require(_detail)
+
+    withKnownIssue {
+      do {
+        let tracker = SharedChangeTracker()
+        tracker.track {
+          detail.withLock { $0 += 1 }
+        }
+      }
+    } matching: {
+      print("# " + $0.description)
+      return $0.description.hasSuffix(
+        """
+        Tracked unasserted changes to 'Shared<CasePathsTraitTests.Route>(value: SharingTests.CasePathsTraitTests.Route.detail(1))': SharingTests.CasePathsTraitTests.Route.detail(0) → SharingTests.CasePathsTraitTests.Route.detail(1)
+        """
+      )
+    }
+  }
+}
+#endif


### PR DESCRIPTION
Based on slack discussion:
https://pointfreecommunity.slack.com/archives/C04L2D8PN4D/p1781144641623609

With the recent soundness hole fix in Swift it is no longer possible to derive a Shared "view" into an enum's case:
```swift
  @CasePathable
  @dynamicMemberLookup
  enum Route: Equatable {
    case detail(Int)
    case settings
  }

  struct Model: Equatable {
    var route: Route
  }
  
  @Shared(value: Model(route: .detail(42))) var model
   let sharedDetail = Shared($model.route.detail) // Cannot assign through dynamic lookup property: '$model' is immutable
```
This PR implements an approach similar to https://github.com/pointfreeco/swift-navigation/blob/7d1f9d77cf4eacde94c8ffa19fe6ba6a9c37bdb7/Sources/SwiftNavigation/UIBinding.swift#L412-L428 that allows to derive a "view" into enum case and it even let's one avoid wrapping in a Shared.init(_):
```swift
@Shared(value: Model(route: .detail(1))) var model
 let sharedDetail = $model.route.detail
```