### PR TITLE
package import Foundation.NSData

### DIFF
--- a/Sources/Sharing/Internal/Deprecations.swift
+++ b/Sources/Sharing/Internal/Deprecations.swift
@@ -1,5 +1,5 @@
 #if canImport(Foundation)
-  package import Foundation
+  package import Foundation.NSData
 #endif
 
 // NB: Deprecated after 2.5.2

--- a/Sources/Sharing/Internal/Deprecations.swift
+++ b/Sources/Sharing/Internal/Deprecations.swift
@@ -1,5 +1,5 @@
 #if canImport(Foundation)
-  package import Foundation.NSData
+  package import struct Foundation.Data
 #endif
 
 // NB: Deprecated after 2.5.2

--- a/Sources/Sharing/Internal/Deprecations.swift
+++ b/Sources/Sharing/Internal/Deprecations.swift
@@ -1,5 +1,5 @@
 #if canImport(Foundation)
-  package import struct Foundation.Data
+  package import Foundation.NSData
 #endif
 
 // NB: Deprecated after 2.5.2


### PR DESCRIPTION
This changes the `package import Foundation` in `Deprecations.swift` to a `package import Foundation.NSData`.

This solves the issue mentioned here https://github.com/pointfreeco/swift-sharing/issues/229 where the release build of our application was failing with errors like this one.

```
ambiguous implicit access level for import of 'Foundation'; it is imported as 'package' elsewhere
[11:36:26]: ▸ import class Foundation.Bundle
```