### PR TITLE
Use default key base when loading shared readers

### DIFF
--- a/Sources/Sharing/SharedKey.swift
+++ b/Sources/Sharing/SharedKey.swift
@@ -82,6 +82,12 @@ extension Shared {
     self.init(wrappedValue: wrappedValue(), key.base)
   }
 
+  /// Replaces a shared reference's key with a shared key that provides a default value and
+  /// attempts to load its value.
+  public func load<K: SharedKey<Value>>(_ key: K.Default) async throws {
+    try await load(key.base)
+  }
+
   /// Replaces a shared reference's key and attempts to load its value.
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
@@ -98,6 +104,12 @@ extension Shared {
       )
     }
     try await load()
+  }
+
+  /// Creates a shared reference from a shared key that provides a default value by loading it
+  /// from its external source.
+  public init<K: SharedKey<Value>>(require key: K.Default) async throws {
+    try await self.init(require: key.base)
   }
 
   /// Creates a shared reference to a value using a shared key by loading it from its external

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -153,6 +153,10 @@ extension SharedReader {
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
+  public func load<K: SharedReaderKey<Value>>(_ key: K.Default) async throws {
+    try await load(key.base)
+  }
+
   public func load(_ key: some SharedReaderKey<Value>) async throws {
     @Dependency(PersistentReferences.self) var persistentReferences
     SharedPublisherLocals.$isLoading.withValue(true) {
@@ -184,6 +188,10 @@ extension SharedReader {
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
+  public init<K: SharedReaderKey<Value>>(require key: K.Default) async throws {
+    try await self.init(require: key.base)
+  }
+
   public init(require key: some SharedReaderKey<Value>) async throws {
     let value = try await withUnsafeThrowingContinuation { continuation in
       key.load(

--- a/Sources/Sharing/SharedReaderKey.swift
+++ b/Sources/Sharing/SharedReaderKey.swift
@@ -149,14 +149,16 @@ extension SharedReader {
     self.init(wrappedValue: wrappedValue(), key.base)
   }
 
-  /// Replaces a shared reference's key and attempts to load its value.
-  ///
-  /// - Parameter key: A shared key associated with the shared reference. It is responsible for
-  ///   loading the shared reference's value from some external source.
+  /// Replaces a shared reference's key with a shared key that provides a default value and
+  /// attempts to load its value.
   public func load<K: SharedReaderKey<Value>>(_ key: K.Default) async throws {
     try await load(key.base)
   }
 
+  /// Replaces a shared reference's key and attempts to load its value.
+  ///
+  /// - Parameter key: A shared key associated with the shared reference. It is responsible for
+  ///   loading the shared reference's value from some external source.
   public func load(_ key: some SharedReaderKey<Value>) async throws {
     @Dependency(PersistentReferences.self) var persistentReferences
     SharedPublisherLocals.$isLoading.withValue(true) {
@@ -177,6 +179,12 @@ extension SharedReader {
     try await load(key)
   }
 
+  /// Creates a shared reference from a shared key that provides a default value by loading it from
+  /// its external source.
+  public init<K: SharedReaderKey<Value>>(require key: K.Default) async throws {
+    try await self.init(require: key.base)
+  }
+
   /// Creates a shared reference to a read-only value using a shared key by loading it from its
   /// external source.
   ///
@@ -188,10 +196,6 @@ extension SharedReader {
   ///
   /// - Parameter key: A shared key associated with the shared reference. It is responsible for
   ///   loading the shared reference's value from some external source.
-  public init<K: SharedReaderKey<Value>>(require key: K.Default) async throws {
-    try await self.init(require: key.base)
-  }
-
   public init(require key: some SharedReaderKey<Value>) async throws {
     let value = try await withUnsafeThrowingContinuation { continuation in
       key.load(

--- a/Tests/SharingTests/DefaultTests.swift
+++ b/Tests/SharingTests/DefaultTests.swift
@@ -163,9 +163,7 @@ import Testing
       try await $value.load(defaultKey)
       @SharedReader(defaultKey) var otherValue
 
-      withExtendedLifetime(($value, $otherValue)) {
-        #expect(subscriptionCount.value == 1)
-      }
+      #expect(subscriptionCount.value == 1)
     }
 
     @Test func requireDefaultKeyUsesBaseReference() async throws {
@@ -179,9 +177,7 @@ import Testing
       let value = try await SharedReader(require: defaultKey)
       @SharedReader(defaultKey) var otherValue
 
-      withExtendedLifetime((value, $otherValue)) {
-        #expect(subscriptionCount.value == 1)
-      }
+      #expect(subscriptionCount.value == 1)
     }
   }
 }

--- a/Tests/SharingTests/DefaultTests.swift
+++ b/Tests/SharingTests/DefaultTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Sharing
 import Testing
 
@@ -149,6 +150,56 @@ import Testing
       #expect(count == 3)
       #expect(countReader == 3)
     }
+
+    @Test func loadDefaultKeyUsesBaseReference() async throws {
+      let subscriptionCount = LockIsolated(0)
+      let key = SubscriptionCountingKey(
+        id: "loadDefaultKeyUsesBaseReference",
+        subscriptionCount: subscriptionCount
+      )
+      let defaultKey = SubscriptionCountingKey.Default[key, default: 0]
+
+      @SharedReader(value: 0) var value
+      try await $value.load(defaultKey)
+      @SharedReader(defaultKey) var otherValue
+
+      withExtendedLifetime(($value, $otherValue)) {
+        #expect(subscriptionCount.value == 1)
+      }
+    }
+
+    @Test func requireDefaultKeyUsesBaseReference() async throws {
+      let subscriptionCount = LockIsolated(0)
+      let key = SubscriptionCountingKey(
+        id: "requireDefaultKeyUsesBaseReference",
+        subscriptionCount: subscriptionCount
+      )
+      let defaultKey = SubscriptionCountingKey.Default[key, default: 0]
+
+      let value = try await SharedReader(require: defaultKey)
+      @SharedReader(defaultKey) var otherValue
+
+      withExtendedLifetime((value, $otherValue)) {
+        #expect(subscriptionCount.value == 1)
+      }
+    }
+  }
+}
+
+private struct SubscriptionCountingKey: SharedReaderKey {
+  let id: String
+  let subscriptionCount: LockIsolated<Int>
+
+  func load(context: LoadContext<Int>, continuation: LoadContinuation<Int>) {
+    continuation.resume(returning: 0)
+  }
+
+  func subscribe(
+    context: LoadContext<Int>,
+    subscriber: SharedSubscriber<Int>
+  ) -> SharedSubscription {
+    subscriptionCount.withValue { $0 += 1 }
+    return SharedSubscription {}
   }
 }
 

--- a/Tests/SharingTests/DefaultTests.swift
+++ b/Tests/SharingTests/DefaultTests.swift
@@ -179,10 +179,39 @@ import Testing
 
       #expect(subscriptionCount.value == 1)
     }
+
+    @Test func sharedLoadDefaultKeyUsesBaseReference() async throws {
+      let subscriptionCount = LockIsolated(0)
+      let key = SubscriptionCountingKey(
+        id: "sharedLoadDefaultKeyUsesBaseReference",
+        subscriptionCount: subscriptionCount
+      )
+      let defaultKey = SubscriptionCountingKey.Default[key, default: 0]
+
+      @Shared(value: 0) var value
+      try await $value.load(defaultKey)
+      @Shared(defaultKey) var otherValue
+
+      #expect(subscriptionCount.value == 1)
+    }
+
+    @Test func sharedRequireDefaultKeyUsesBaseReference() async throws {
+      let subscriptionCount = LockIsolated(0)
+      let key = SubscriptionCountingKey(
+        id: "sharedRequireDefaultKeyUsesBaseReference",
+        subscriptionCount: subscriptionCount
+      )
+      let defaultKey = SubscriptionCountingKey.Default[key, default: 0]
+
+      let value = try await Shared(require: defaultKey)
+      @Shared(defaultKey) var otherValue
+
+      #expect(subscriptionCount.value == 1)
+    }
   }
 }
 
-private struct SubscriptionCountingKey: SharedReaderKey {
+private struct SubscriptionCountingKey: SharedKey {
   let id: String
   let subscriptionCount: LockIsolated<Int>
 
@@ -196,6 +225,10 @@ private struct SubscriptionCountingKey: SharedReaderKey {
   ) -> SharedSubscription {
     subscriptionCount.withValue { $0 += 1 }
     return SharedSubscription {}
+  }
+
+  func save(_ value: Int, context: SaveContext, continuation: SaveContinuation) {
+    continuation.resume()
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/pointfreeco/swift-sharing/issues/233.

`SharedReader.load(_:)` and `SharedReader.init(require:)` currently use a `SharedReaderKey.Default` wrapper as the persistent-reference lookup key, while the synchronous default-key initializer uses `key.base`.

Mixing these APIs therefore looks up the same ID using different concrete key types, creating a second reference and subscription.

This adds `K.Default` overloads that forward to `key.base`, matching the existing initializer behavior. It also adds regression tests covering both `load` and `require` followed by a property-wrapper reader.
