### PR TITLE
Fix WasmDemo package resolution from renamed checkouts

### DIFF
--- a/Examples/WasmDemo/Package.swift
+++ b/Examples/WasmDemo/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     .macOS(.v14)
   ],
   dependencies: [
-    .package(path: "../.."),
+    .package(name: "swift-sharing", path: "../.."),
     .package(url: "https://github.com/pointfreeco/swift-navigation", from: "2.0.0"),
     .package(url: "https://github.com/swiftwasm/carton", from: "1.0.0"),
     .package(url: "https://github.com/swiftwasm/JavaScriptKit", exact: "0.21.0"),


### PR DESCRIPTION
The WasmDemo manifest relies on SwiftPM deriving the local package identity from the repository directory name. In a worktree or renamed checkout, the identity differs from `swift-sharing`, so workspace package resolution fails.

Declare `swift-sharing` as the local dependency's package name so the existing product dependency resolves independently of the checkout directory.