### PR TITLE
Disambiguate optional `SharedReader` initialization

### DIFF
--- a/Sources/Sharing/Documentation.docc/Extensions/SharedReader.md
+++ b/Sources/Sharing/Documentation.docc/Extensions/SharedReader.md
@@ -68,6 +68,7 @@ if remoteConfig.isToggleEnabled {
 
 - ``subscript(dynamicMember:)``
 - ``init(_:)``
+- ``init(unwrapping:)``
 
 ### Reading the value
 

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -84,17 +84,22 @@ public struct SharedReader<Value> {
   /// Unwraps a read-only shared reference to an optional value.
   ///
   /// ```swift
-  /// @SharedReader(.currentUser) var currentUser: User?
+  /// @Shared(.currentUser) var currentUser: User?
   ///
-  /// if let sharedUnwrappedUser = SharedReader($currentUser) {
+  /// if let sharedUnwrappedUser = SharedReader(unwrapping: $currentUser) {
   ///   sharedUnwrappedUser  // SharedReader<User>
   /// }
   /// ```
   ///
-  /// - Parameter base: A read-only shared reference to an optional value.
+  /// - Parameter base: A shared reference to an optional value.
+  public init?(unwrapping base: Shared<Value?>) {
+    self.init(unwrapping: SharedReader<Value?>(base))
+  }
+
+  @available(*, deprecated, renamed: "init(unwrapping:)")
   @_disfavoredOverload
   public init?(_ base: Shared<Value?>) {
-    self.init(SharedReader<Value?>(base))
+    self.init(unwrapping: base)
   }
 
   /// Unwraps a read-only shared reference to an optional value.
@@ -102,19 +107,24 @@ public struct SharedReader<Value> {
   /// ```swift
   /// @SharedReader(.currentUser) var currentUser: User?
   ///
-  /// if let sharedUnwrappedUser = SharedReader($currentUser) {
+  /// if let sharedUnwrappedUser = SharedReader(unwrapping: $currentUser) {
   ///   sharedUnwrappedUser  // SharedReader<User>
   /// }
   /// ```
   ///
   /// - Parameter base: A read-only shared reference to an optional value.
-  @_disfavoredOverload
-  public init?(_ base: SharedReader<Value?>) {
+  public init?(unwrapping base: SharedReader<Value?>) {
     guard let initialValue = base.wrappedValue else { return nil }
     func open(_ reference: some Reference<Value?>) -> any Reference<Value> {
       _OptionalReference(base: reference, initialValue: initialValue)
     }
     self.init(reference: open(base.reference))
+  }
+
+  @available(*, deprecated, renamed: "init(unwrapping:)")
+  @_disfavoredOverload
+  public init?(_ base: SharedReader<Value?>) {
+    self.init(unwrapping: base)
   }
 
   /// Creates a read-only shared reference from another read-only shared reference.

--- a/Sources/Sharing/SharedReader.swift
+++ b/Sources/Sharing/SharedReader.swift
@@ -92,6 +92,7 @@ public struct SharedReader<Value> {
   /// ```
   ///
   /// - Parameter base: A read-only shared reference to an optional value.
+  @_disfavoredOverload
   public init?(_ base: Shared<Value?>) {
     self.init(SharedReader<Value?>(base))
   }
@@ -107,6 +108,7 @@ public struct SharedReader<Value> {
   /// ```
   ///
   /// - Parameter base: A read-only shared reference to an optional value.
+  @_disfavoredOverload
   public init?(_ base: SharedReader<Value?>) {
     guard let initialValue = base.wrappedValue else { return nil }
     func open(_ reference: some Reference<Value?>) -> any Reference<Value> {

--- a/Sources/Sharing/Traits/CasePaths.swift
+++ b/Sources/Sharing/Traits/CasePaths.swift
@@ -33,7 +33,7 @@
             base: reference, keyPath: keyPath.unsafeSendable())
         )
       }
-      return SharedReader<Member>(open(reference))
+      return SharedReader<Member>(unwrapping: open(reference))
     }
   }
 

--- a/Sources/Sharing/Traits/IdentifiedCollections.swift
+++ b/Sources/Sharing/Traits/IdentifiedCollections.swift
@@ -48,7 +48,7 @@
       let value = shared.wrappedValue
       self.reserveCapacity(value.count)
       for id in value.ids {
-        self.append(SharedReader(shared[id: id])!)
+        self.append(SharedReader(unwrapping: shared[id: id])!)
       }
     }
   }

--- a/Tests/SharingTests/CompileTimeTests.swift
+++ b/Tests/SharingTests/CompileTimeTests.swift
@@ -30,6 +30,12 @@ func testSharedReaderInitializerOverload() async throws {
   _ = SharedReader(wrappedValue: 42, .count)
 }
 
+func testSharedReaderOptionalInitializerOverload() {
+  @Shared(value: 42) var count: Int?
+  let reader = SharedReader($count)
+  let _: SharedReader<Int?> = reader
+}
+
 func testSharedReaderLoadOverload() async throws {
   let shared = SharedReader(wrappedValue: 42, .count)
   try await shared.load(.count)

--- a/Tests/SharingTests/CompileTimeTests.swift
+++ b/Tests/SharingTests/CompileTimeTests.swift
@@ -32,8 +32,16 @@ func testSharedReaderInitializerOverload() async throws {
 
 func testSharedReaderOptionalInitializerOverload() {
   @Shared(value: 42) var count: Int?
-  let reader = SharedReader($count)
-  let _: SharedReader<Int?> = reader
+  let optionalReader = SharedReader($count)
+  let _: SharedReader<Int?> = optionalReader
+
+  if let reader = SharedReader(unwrapping: $count) {
+    let _: SharedReader<Int> = reader
+  }
+
+  if let reader = SharedReader(unwrapping: optionalReader) {
+    let _: SharedReader<Int> = reader
+  }
 }
 
 func testSharedReaderLoadOverload() async throws {


### PR DESCRIPTION
Calling `SharedReader($value)` for a `Shared<Value?>` currently selects the failable optional-unwrapping initializer and infers `SharedReader<Value>?`. This makes preserving the optional value require an explicit result type.

This PR adds labeled `SharedReader(unwrapping:)` initializers for both `Shared` and `SharedReader` inputs. It retains the unlabeled failable initializers as deprecated, disfavored overloads:

```swift
let reader = SharedReader($value)  // SharedReader<Value?>

if let reader = SharedReader(unwrapping: $value) {
  // SharedReader<Value>
}
```

Explicitly contextualized uses of the unlabeled failable initializers continue to compile with a deprecation warning. A plain `if let reader = SharedReader($value)` no longer compiles because optional binding does not contribute result context during overload selection. That compiler behavior is tracked in [swiftlang/swift#91382](https://github.com/swiftlang/swift/issues/91382).

If that source incompatibility is too strict for a 2.x release, this change can be considered for 3.0.0.