### PR TITLE
Revert "package import Foundation.NSData (#231)"

### DIFF
--- a/Sources/Sharing/Internal/Deprecations.swift
+++ b/Sources/Sharing/Internal/Deprecations.swift
@@ -1,5 +1,5 @@
 #if canImport(Foundation)
-  package import Foundation.NSData
+  package import Foundation
 #endif
 
 // NB: Deprecated after 2.5.2


### PR DESCRIPTION
This reverts commit 4dfe1b9751bb6cd1a34b363310f43b634f8b5645.

While the syntax works on macOS, that seems to be an Objective-C fluke, and we're seeing failures on Linux now.

@JanGorman I think we'll need some kind of integration-style test to address this. Our Linux CI started failing with this:

```
Sources/Sharing/Internal/Deprecations.swift:2:18: error: no such module 'Foundation.NSData'
 1 | #if canImport(Foundation)
 2 |   package import Foundation.NSData
   |                  `- error: no such module 'Foundation.NSData'
 3 | #endif
 4 | 
```

And unfortunately doing the `package import class` syntax introduces a warning we can't suppress. Ideally there's a workaround that doesn't require a warning that might get accidentally "fixed" later on.

We're going to revert for now, but let us know if you want to dig in deeper.